### PR TITLE
Add realtime guests, ideas, and budget sections

### DIFF
--- a/app.js
+++ b/app.js
@@ -298,6 +298,60 @@ const waitForFirebaseSync = () => {
   });
 };
 
+const getFirebaseSession = () =>
+  typeof window !== 'undefined' && window.FirebaseSession ? window.FirebaseSession : null;
+
+const waitForFirebaseSession = () => {
+  const existing = getFirebaseSession();
+
+  if (existing) {
+    return Promise.resolve(existing);
+  }
+
+  if (typeof window === 'undefined') {
+    return Promise.resolve(null);
+  }
+
+  return new Promise((resolve) => {
+    const handleReady = () => {
+      window.removeEventListener('firebase-sync-ready', handleReady);
+      resolve(getFirebaseSession());
+    };
+
+    window.addEventListener('firebase-sync-ready', handleReady, { once: true });
+  });
+};
+
+const waitForCurrentUser = () =>
+  waitForFirebaseSession().then((session) => {
+    if (!session || typeof session.waitForAuth !== 'function') {
+      return null;
+    }
+
+    return session
+      .waitForAuth()
+      .then((user) => user)
+      .catch((error) => {
+        console.warn('No se pudo obtener la sesión de usuario de Firebase.', error);
+        return null;
+      });
+  });
+
+const getCurrentUser = () => {
+  const session = getFirebaseSession();
+
+  if (!session || typeof session.getCurrentUser !== 'function') {
+    return null;
+  }
+
+  try {
+    return session.getCurrentUser();
+  } catch (error) {
+    console.warn('No se pudo leer el usuario actual de Firebase.', error);
+    return null;
+  }
+};
+
 const createFirebaseController = (syncInstance = getFirebaseSync()) => {
   const sync = syncInstance;
 
@@ -710,6 +764,1777 @@ list.addEventListener('click', (event) => {
   }
 });
 
+const sanitizeEntityText = (value) =>
+  typeof value === 'string' ? value.trim() : '';
+
+// Invitados
+const RSVP_LABELS = {
+  yes: 'Confirmado',
+  pending: 'Pendiente',
+  no: 'Rechazado',
+};
+const SIDE_LABELS = {
+  novia: 'Novia',
+  novio: 'Novio',
+  ambos: 'Ambos',
+};
+
+const guestForm = document.getElementById('guest-form');
+const guestNameInput = document.getElementById('guest-name');
+const guestSideSelect = document.getElementById('guest-side');
+const guestGroupInput = document.getElementById('guest-group');
+const guestRsvpSelect = document.getElementById('guest-rsvp');
+const guestPlusInput = document.getElementById('guest-plus');
+const guestContactInput = document.getElementById('guest-contact');
+const guestDietaryInput = document.getElementById('guest-dietary');
+const guestNotesInput = document.getElementById('guest-notes');
+const guestList = document.getElementById('guest-list');
+const guestSearchInput = document.getElementById('guest-search');
+const guestRsvpFilter = document.getElementById('guest-rsvp-filter');
+const guestGroupFilter = document.getElementById('guest-group-filter');
+const guestExportButton = document.getElementById('guest-export');
+
+const guestCounters = {
+  total: document.getElementById('guest-total'),
+  confirmed: document.getElementById('guest-confirmed'),
+  pending: document.getElementById('guest-pending'),
+  people: document.getElementById('guest-people'),
+};
+
+const guestFiltersState = {
+  search: '',
+  rsvp: '',
+  group: '',
+};
+
+const isValidGuestSide = (value) => Object.prototype.hasOwnProperty.call(SIDE_LABELS, value);
+const isValidGuestRsvp = (value) => Object.prototype.hasOwnProperty.call(RSVP_LABELS, value);
+
+const normalizeGuestRecord = (id, record) => {
+  if (!record || typeof record !== 'object') {
+    return null;
+  }
+
+  const name = sanitizeEntityText(record.name);
+
+  if (!name) {
+    return null;
+  }
+
+  const plus = Number.parseInt(record.plusOnes, 10);
+
+  return {
+    id,
+    name,
+    side: isValidGuestSide(record.side) ? record.side : 'ambos',
+    group: sanitizeEntityText(record.group),
+    rsvp: isValidGuestRsvp(record.rsvp) ? record.rsvp : 'pending',
+    plusOnes: Number.isFinite(plus) ? Math.max(0, plus) : 0,
+    dietary: sanitizeEntityText(record.dietary),
+    notes: sanitizeEntityText(record.notes),
+    contact: sanitizeEntityText(record.contact),
+    createdAt: toTimestamp(record.createdAt),
+    updatedAt: toTimestamp(record.updatedAt),
+    createdBy: sanitizeEntityText(record.createdBy),
+  };
+};
+
+const mapGuestRecords = (records) =>
+  Object.entries(records ?? {})
+    .map(([id, value]) => normalizeGuestRecord(id, value))
+    .filter((value) => value !== null)
+    .sort((first, second) =>
+      first.name.localeCompare(second.name, 'es', { sensitivity: 'base' }),
+    );
+
+const createGuestsStore = () => {
+  let sync = null;
+  let unsubscribe = () => {};
+  let rawRecords = {};
+  let guests = [];
+  const listeners = new Set();
+
+  const emit = () => {
+    const snapshot = {
+      guests: guests.map((guest) => ({ ...guest })),
+      raw: { ...rawRecords },
+    };
+    listeners.forEach((listener) => listener(snapshot));
+  };
+
+  const ensureSync = async () => {
+    if (sync) {
+      return sync;
+    }
+
+    const instance = await waitForFirebaseSync();
+    if (!instance) {
+      throw new Error('SYNC_UNAVAILABLE');
+    }
+
+    sync = instance;
+    return sync;
+  };
+
+  const init = () =>
+    ensureSync()
+      .then((instance) => {
+        if (!instance || typeof instance.listenGuests !== 'function') {
+          return;
+        }
+
+        unsubscribe();
+        unsubscribe = () => {};
+
+        try {
+          const stop = instance.listenGuests((records) => {
+            rawRecords = records ?? {};
+            guests = mapGuestRecords(records);
+            emit();
+          });
+
+          unsubscribe = typeof stop === 'function' ? stop : () => {};
+        } catch (error) {
+          console.warn('No se pudo iniciar la escucha de invitados.', error);
+        }
+      })
+      .catch((error) => {
+        console.warn('No se pudo iniciar la sincronización de invitados.', error);
+      });
+
+  const subscribe = (listener) => {
+    listeners.add(listener);
+    listener({
+      guests: guests.map((guest) => ({ ...guest })),
+      raw: { ...rawRecords },
+    });
+
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  const addGuest = (payload) =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.addGuest !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.addGuest(payload);
+    });
+
+  const updateGuest = (guestId, changes) =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.updateGuest !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.updateGuest(guestId, changes);
+    });
+
+  const deleteGuest = (guestId) =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.deleteGuest !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.deleteGuest(guestId);
+    });
+
+  const exportCSV = () =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.exportGuestsCSV !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.exportGuestsCSV(rawRecords);
+    });
+
+  const destroy = () => {
+    try {
+      unsubscribe();
+    } catch (error) {
+      console.warn('No se pudo detener la escucha de invitados.', error);
+    }
+    unsubscribe = () => {};
+    listeners.clear();
+  };
+
+  const getSnapshot = () => ({
+    guests: guests.map((guest) => ({ ...guest })),
+    raw: { ...rawRecords },
+  });
+
+  return {
+    init,
+    subscribe,
+    addGuest,
+    updateGuest,
+    deleteGuest,
+    exportCSV,
+    destroy,
+    getSnapshot,
+  };
+};
+
+const guestsStore = createGuestsStore();
+
+let guestsData = [];
+let guestRawRecords = {};
+
+const applyGuestFilters = (items) => {
+  const search = guestFiltersState.search;
+  const rsvpFilter = guestFiltersState.rsvp;
+  const groupFilter = guestFiltersState.group;
+
+  return items.filter((guest) => {
+    if (search && !guest.name.toLowerCase().includes(search)) {
+      return false;
+    }
+
+    if (rsvpFilter && guest.rsvp !== rsvpFilter) {
+      return false;
+    }
+
+    if (groupFilter && guest.group !== groupFilter) {
+      return false;
+    }
+
+    return true;
+  });
+};
+
+const renderGuestSummary = () => {
+  if (!guestCounters.total) {
+    return;
+  }
+
+  const total = guestsData.length;
+  const confirmed = guestsData.filter((guest) => guest.rsvp === 'yes').length;
+  const pending = guestsData.filter((guest) => guest.rsvp === 'pending').length;
+  const people = guestsData.reduce(
+    (sum, guest) => sum + 1 + Math.max(0, guest.plusOnes || 0),
+    0,
+  );
+
+  guestCounters.total.textContent = String(total);
+  guestCounters.confirmed.textContent = String(confirmed);
+  guestCounters.pending.textContent = String(pending);
+  guestCounters.people.textContent = String(people);
+};
+
+const buildGuestMetaText = (guest) => {
+  const parts = [];
+
+  parts.push(SIDE_LABELS[guest.side] || guest.side);
+
+  if (guest.group) {
+    parts.push(`Grupo: ${guest.group}`);
+  }
+
+  parts.push(`Personas: ${1 + Math.max(0, guest.plusOnes || 0)}`);
+
+  return parts.join(' • ');
+};
+
+const createGuestCard = (guest) => {
+  const item = document.createElement('li');
+  item.className = 'guest-card';
+  item.dataset.id = guest.id;
+
+  const header = document.createElement('div');
+  header.className = 'guest-card__header';
+
+  const headerContent = document.createElement('div');
+  headerContent.className = 'guest-card__header-content';
+
+  const name = document.createElement('h3');
+  name.className = 'guest-card__name';
+  name.textContent = guest.name;
+
+  const meta = document.createElement('p');
+  meta.className = 'guest-card__meta';
+  meta.textContent = buildGuestMetaText(guest);
+
+  headerContent.append(name, meta);
+
+  const deleteButton = document.createElement('button');
+  deleteButton.type = 'button';
+  deleteButton.className = 'guest-card__delete';
+  deleteButton.textContent = 'Eliminar';
+  deleteButton.setAttribute('aria-label', `Eliminar invitado: ${guest.name}`);
+
+  header.append(headerContent, deleteButton);
+
+  const controls = document.createElement('div');
+  controls.className = 'guest-card__controls';
+
+  const rsvpField = document.createElement('label');
+  rsvpField.className = 'guest-card__field';
+  rsvpField.textContent = 'Asistencia';
+
+  const rsvpSelect = document.createElement('select');
+  rsvpSelect.className = 'guest-card__rsvp';
+  rsvpSelect.setAttribute('aria-label', `Estado de ${guest.name}`);
+
+  Object.entries(RSVP_LABELS).forEach(([value, label]) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = label;
+    rsvpSelect.append(option);
+  });
+  rsvpSelect.value = guest.rsvp;
+
+  rsvpField.append(rsvpSelect);
+
+  const plusField = document.createElement('label');
+  plusField.className = 'guest-card__field';
+  plusField.textContent = 'Acompañantes';
+
+  const plusInput = document.createElement('input');
+  plusInput.className = 'guest-card__plus';
+  plusInput.type = 'number';
+  plusInput.min = '0';
+  plusInput.step = '1';
+  plusInput.value = String(Math.max(0, guest.plusOnes || 0));
+  plusInput.setAttribute('aria-label', `Acompañantes de ${guest.name}`);
+
+  plusField.append(plusInput);
+
+  controls.append(rsvpField, plusField);
+
+  const details = document.createElement('div');
+  details.className = 'guest-card__details';
+
+  const createDetailField = (labelText, value, className, { multiline = false } = {}) => {
+    const wrapper = document.createElement('label');
+    wrapper.className = 'guest-card__field';
+
+    const title = document.createElement('span');
+    title.className = 'guest-card__field-label';
+    title.textContent = labelText;
+    wrapper.append(title);
+
+    if (multiline) {
+      const textarea = document.createElement('textarea');
+      textarea.className = className;
+      textarea.rows = 2;
+      textarea.value = value || '';
+      textarea.placeholder = 'Añade una nota';
+      wrapper.append(textarea);
+      return wrapper;
+    }
+
+    const input = document.createElement('input');
+    input.className = className;
+    input.type = 'text';
+    input.value = value || '';
+    wrapper.append(input);
+    return wrapper;
+  };
+
+  const contactField = createDetailField('Contacto', guest.contact, 'guest-card__contact');
+  const dietaryField = createDetailField(
+    'Restricciones',
+    guest.dietary,
+    'guest-card__dietary',
+  );
+  const notesField = createDetailField('Notas', guest.notes, 'guest-card__notes', {
+    multiline: true,
+  });
+
+  details.append(contactField, dietaryField, notesField);
+
+  item.append(header, controls, details);
+
+  return item;
+};
+
+const renderGuestList = () => {
+  if (!guestList) {
+    return;
+  }
+
+  guestList.innerHTML = '';
+
+  const filtered = applyGuestFilters(guestsData);
+
+  if (!filtered.length) {
+    const empty = document.createElement('li');
+    empty.className = 'guest-card guest-card--empty';
+
+    const message = document.createElement('p');
+    message.className = 'guest-card__empty-message';
+    message.textContent = guestsData.length
+      ? 'No hay invitados que coincidan con los filtros.'
+      : 'Añade invitados para comenzar.';
+
+    empty.append(message);
+    guestList.append(empty);
+    return;
+  }
+
+  filtered.forEach((guest) => {
+    guestList.append(createGuestCard(guest));
+  });
+};
+
+const updateGuestGroupFilter = () => {
+  if (!guestGroupFilter) {
+    return;
+  }
+
+  const currentValue = guestGroupFilter.value;
+
+  Array.from(guestGroupFilter.options)
+    .slice(1)
+    .forEach((option) => option.remove());
+
+  const groups = Array.from(
+    new Set(guestsData.map((guest) => guest.group).filter((group) => Boolean(group))),
+  ).sort((first, second) => first.localeCompare(second, 'es', { sensitivity: 'base' }));
+
+  groups.forEach((group) => {
+    const option = document.createElement('option');
+    option.value = group;
+    option.textContent = group;
+    guestGroupFilter.append(option);
+  });
+
+  if (currentValue && !groups.includes(currentValue)) {
+    guestGroupFilter.value = '';
+    guestFiltersState.group = '';
+  } else if (currentValue) {
+    guestGroupFilter.value = currentValue;
+  }
+};
+
+const resetGuestForm = () => {
+  if (!guestForm) {
+    return;
+  }
+
+  guestForm.reset();
+
+  if (guestSideSelect) {
+    guestSideSelect.value = 'novia';
+  }
+
+  if (guestRsvpSelect) {
+    guestRsvpSelect.value = 'pending';
+  }
+
+  if (guestPlusInput) {
+    guestPlusInput.value = '0';
+  }
+};
+
+const handleGuestFormSubmit = (event) => {
+  event.preventDefault();
+
+  if (!guestForm) {
+    return;
+  }
+
+  const payload = {
+    name: guestNameInput ? guestNameInput.value : '',
+    side: guestSideSelect ? guestSideSelect.value : 'ambos',
+    group: guestGroupInput ? guestGroupInput.value : '',
+    rsvp: guestRsvpSelect ? guestRsvpSelect.value : 'pending',
+    plusOnes: guestPlusInput ? Number.parseInt(guestPlusInput.value, 10) || 0 : 0,
+    contact: guestContactInput ? guestContactInput.value : '',
+    dietary: guestDietaryInput ? guestDietaryInput.value : '',
+    notes: guestNotesInput ? guestNotesInput.value : '',
+  };
+
+  const submission = guestsStore.addGuest(payload);
+
+  resetGuestForm();
+
+  if (guestNameInput) {
+    guestNameInput.focus();
+  }
+
+  if (submission && typeof submission.catch === 'function') {
+    submission.catch((error) => {
+      console.error('No se pudo guardar el invitado.', error);
+      alert('No se pudo guardar el invitado. Revisa tu conexión e inténtalo nuevamente.');
+    });
+  }
+};
+
+const handleGuestListChange = (event) => {
+  const target = event.target;
+
+  if (!(target instanceof HTMLElement)) {
+    return;
+  }
+
+  const card = target.closest('.guest-card');
+
+  if (!card) {
+    return;
+  }
+
+  const guestId = card.dataset.id;
+
+  if (!guestId) {
+    return;
+  }
+
+  let changes = null;
+
+  if (target.matches('.guest-card__rsvp')) {
+    changes = { rsvp: target.value };
+  } else if (target.matches('.guest-card__plus')) {
+    changes = { plusOnes: Number.parseInt(target.value, 10) || 0 };
+  } else if (target.matches('.guest-card__contact')) {
+    changes = { contact: target.value };
+  } else if (target.matches('.guest-card__dietary')) {
+    changes = { dietary: target.value };
+  } else if (target.matches('.guest-card__notes')) {
+    changes = { notes: target.value };
+  }
+
+  if (!changes) {
+    return;
+  }
+
+  const update = guestsStore.updateGuest(guestId, changes);
+
+  if (update && typeof update.catch === 'function') {
+    update.catch((error) => {
+      console.error('No se pudo actualizar el invitado.', error);
+      alert('No se pudo actualizar el invitado. Inténtalo nuevamente.');
+    });
+  }
+};
+
+const handleGuestListClick = (event) => {
+  const target = event.target;
+
+  if (!(target instanceof HTMLButtonElement) || !target.matches('.guest-card__delete')) {
+    return;
+  }
+
+  const card = target.closest('.guest-card');
+
+  if (!card) {
+    return;
+  }
+
+  const guestId = card.dataset.id;
+
+  if (!guestId) {
+    return;
+  }
+
+  const confirmed = window.confirm('¿Quieres eliminar este invitado?');
+
+  if (!confirmed) {
+    return;
+  }
+
+  const removal = guestsStore.deleteGuest(guestId);
+
+  if (removal && typeof removal.catch === 'function') {
+    removal.catch((error) => {
+      console.error('No se pudo eliminar el invitado.', error);
+      alert('No se pudo eliminar el invitado. Inténtalo nuevamente.');
+    });
+  }
+};
+
+const handleGuestSearchInput = (event) => {
+  const value = typeof event.target.value === 'string' ? event.target.value : '';
+  guestFiltersState.search = value.trim().toLowerCase();
+  renderGuestList();
+};
+
+const handleGuestRsvpFilterChange = (event) => {
+  guestFiltersState.rsvp = event.target.value;
+  renderGuestList();
+};
+
+const handleGuestGroupFilterChange = (event) => {
+  guestFiltersState.group = event.target.value;
+  renderGuestList();
+};
+
+const downloadCsv = (content, filename) => {
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};
+
+const handleGuestExport = () => {
+  const exportAction = guestsStore.exportCSV();
+
+  if (!exportAction || typeof exportAction.then !== 'function') {
+    return;
+  }
+
+  exportAction
+    .then((csv) => {
+      if (!csv) {
+        alert('No hay datos para exportar todavía.');
+        return;
+      }
+
+      const filename = `invitados-${new Date().toISOString().slice(0, 10)}.csv`;
+      downloadCsv(csv, filename);
+    })
+    .catch((error) => {
+      console.error('No se pudo exportar la lista de invitados.', error);
+      alert('No se pudo exportar la lista de invitados. Inténtalo nuevamente.');
+    });
+};
+
+const initializeGuestSection = () => {
+  if (!guestForm || !guestList) {
+    return;
+  }
+
+  guestsStore.subscribe(({ guests, raw }) => {
+    guestsData = guests;
+    guestRawRecords = raw;
+    updateGuestGroupFilter();
+    renderGuestSummary();
+    renderGuestList();
+  });
+
+  guestsStore.init();
+
+  guestForm.addEventListener('submit', handleGuestFormSubmit);
+
+  if (guestSearchInput) {
+    guestSearchInput.addEventListener('input', handleGuestSearchInput);
+  }
+
+  if (guestRsvpFilter) {
+    guestRsvpFilter.addEventListener('change', handleGuestRsvpFilterChange);
+  }
+
+  if (guestGroupFilter) {
+    guestGroupFilter.addEventListener('change', handleGuestGroupFilterChange);
+  }
+
+  guestList.addEventListener('change', handleGuestListChange);
+  guestList.addEventListener('click', handleGuestListClick);
+
+  if (guestExportButton) {
+    guestExportButton.addEventListener('click', handleGuestExport);
+  }
+};
+
+// Ideas
+const ideaForm = document.getElementById('idea-form');
+const ideaTitleInput = document.getElementById('idea-title');
+const ideaUrlInput = document.getElementById('idea-url');
+const ideaCategoryInput = document.getElementById('idea-category');
+const ideaNoteInput = document.getElementById('idea-note');
+const ideaSearchInput = document.getElementById('idea-search');
+const ideaCategoryFilter = document.getElementById('idea-category-filter');
+const ideasGrid = document.getElementById('ideas-grid');
+
+const normalizeIdeaRecord = (id, record) => {
+  if (!record || typeof record !== 'object') {
+    return null;
+  }
+
+  const title = sanitizeEntityText(record.title);
+
+  if (!title) {
+    return null;
+  }
+
+  const likes =
+    record.likes && typeof record.likes === 'object' ? record.likes : {};
+
+  return {
+    id,
+    title,
+    url: sanitizeEntityText(record.url),
+    category: sanitizeEntityText(record.category) || 'Sin categoría',
+    note: sanitizeEntityText(record.note),
+    likes,
+    createdAt: toTimestamp(record.createdAt),
+    updatedAt: toTimestamp(record.updatedAt),
+    createdBy: sanitizeEntityText(record.createdBy),
+  };
+};
+
+const mapIdeaRecords = (records) =>
+  Object.entries(records ?? {})
+    .map(([id, value]) => normalizeIdeaRecord(id, value))
+    .filter((value) => value !== null)
+    .sort((first, second) => {
+      const firstTime = typeof first.createdAt === 'number' ? first.createdAt : 0;
+      const secondTime = typeof second.createdAt === 'number' ? second.createdAt : 0;
+      return secondTime - firstTime;
+    });
+
+const createIdeasStore = () => {
+  let sync = null;
+  let unsubscribe = () => {};
+  let ideas = [];
+  let rawRecords = {};
+  const listeners = new Set();
+
+  const emit = () => {
+    const snapshot = {
+      ideas: ideas.map((idea) => ({ ...idea })),
+      raw: { ...rawRecords },
+    };
+    listeners.forEach((listener) => listener(snapshot));
+  };
+
+  const ensureSync = async () => {
+    if (sync) {
+      return sync;
+    }
+
+    const instance = await waitForFirebaseSync();
+    if (!instance) {
+      throw new Error('SYNC_UNAVAILABLE');
+    }
+
+    sync = instance;
+    return sync;
+  };
+
+  const init = () =>
+    ensureSync()
+      .then((instance) => {
+        if (!instance || typeof instance.listenIdeas !== 'function') {
+          return;
+        }
+
+        unsubscribe();
+        unsubscribe = () => {};
+
+        try {
+          const stop = instance.listenIdeas((records) => {
+            rawRecords = records ?? {};
+            ideas = mapIdeaRecords(records);
+            emit();
+          });
+
+          unsubscribe = typeof stop === 'function' ? stop : () => {};
+        } catch (error) {
+          console.warn('No se pudo iniciar la escucha de ideas.', error);
+        }
+      })
+      .catch((error) => {
+        console.warn('No se pudo iniciar la sincronización de ideas.', error);
+      });
+
+  const subscribe = (listener) => {
+    listeners.add(listener);
+    listener({ ideas: ideas.map((idea) => ({ ...idea })), raw: { ...rawRecords } });
+
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  const addIdea = (payload, uid) =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.addIdea !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.addIdea(payload, uid);
+    });
+
+  const toggleLike = (ideaId, uid, isLiked) =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.toggleLike !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.toggleLike(ideaId, uid, isLiked);
+    });
+
+  const deleteIdea = (ideaId) =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.deleteIdea !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.deleteIdea(ideaId);
+    });
+
+  const destroy = () => {
+    try {
+      unsubscribe();
+    } catch (error) {
+      console.warn('No se pudo detener la escucha de ideas.', error);
+    }
+    unsubscribe = () => {};
+    listeners.clear();
+  };
+
+  const getSnapshot = () => ({
+    ideas: ideas.map((idea) => ({ ...idea })),
+    raw: { ...rawRecords },
+  });
+
+  return {
+    init,
+    subscribe,
+    addIdea,
+    toggleLike,
+    deleteIdea,
+    destroy,
+    getSnapshot,
+  };
+};
+
+const ideasStore = createIdeasStore();
+
+let ideasData = [];
+const ideaFilters = {
+  search: '',
+  category: '',
+};
+let currentIdeaUserId = null;
+
+const applyIdeaFilters = (ideas) => {
+  const search = ideaFilters.search;
+  const category = ideaFilters.category;
+
+  return ideas.filter((idea) => {
+    if (search && !idea.title.toLowerCase().includes(search)) {
+      return false;
+    }
+
+    if (category && idea.category !== category) {
+      return false;
+    }
+
+    return true;
+  });
+};
+
+const createIdeaCard = (idea, uid) => {
+  const card = document.createElement('article');
+  card.className = 'idea-card';
+  card.dataset.id = idea.id;
+
+  const header = document.createElement('header');
+  header.className = 'idea-card__header';
+
+  const titleElement = idea.url ? document.createElement('a') : document.createElement('h3');
+  titleElement.className = 'idea-card__title';
+  titleElement.textContent = idea.title;
+
+  if (idea.url) {
+    titleElement.href = idea.url;
+    titleElement.target = '_blank';
+    titleElement.rel = 'noopener noreferrer';
+  }
+
+  const category = document.createElement('span');
+  category.className = 'idea-card__category';
+  category.textContent = idea.category;
+
+  header.append(titleElement, category);
+  card.append(header);
+
+  if (idea.note) {
+    const note = document.createElement('p');
+    note.className = 'idea-card__note';
+    note.textContent = idea.note;
+    card.append(note);
+  }
+
+  const footer = document.createElement('footer');
+  footer.className = 'idea-card__footer';
+
+  const likesCount = idea.likes ? Object.keys(idea.likes).length : 0;
+  const isLiked = uid ? Boolean(idea.likes && idea.likes[uid]) : false;
+
+  const likeButton = document.createElement('button');
+  likeButton.type = 'button';
+  likeButton.className = 'idea-card__like';
+  likeButton.textContent = `❤️ ${likesCount}`;
+  likeButton.dataset.count = String(likesCount);
+  likeButton.dataset.liked = String(isLiked);
+  likeButton.setAttribute('aria-pressed', String(isLiked));
+  likeButton.title = uid
+    ? isLiked
+      ? 'Quitar de favoritos'
+      : 'Marcar como favorito'
+    : 'Conectando con la base de datos...';
+
+  if (isLiked) {
+    likeButton.classList.add('is-liked');
+  }
+
+  if (!uid) {
+    likeButton.disabled = true;
+  }
+
+  const deleteButton = document.createElement('button');
+  deleteButton.type = 'button';
+  deleteButton.className = 'idea-card__delete';
+  deleteButton.textContent = 'Eliminar';
+  deleteButton.setAttribute('aria-label', `Eliminar idea: ${idea.title}`);
+
+  footer.append(likeButton, deleteButton);
+  card.append(footer);
+
+  return card;
+};
+
+const updateIdeasCategoryFilter = () => {
+  if (!ideaCategoryFilter) {
+    return;
+  }
+
+  const currentValue = ideaCategoryFilter.value;
+
+  Array.from(ideaCategoryFilter.options)
+    .slice(1)
+    .forEach((option) => option.remove());
+
+  const categories = Array.from(
+    new Set(ideasData.map((idea) => idea.category).filter((category) => Boolean(category))),
+  ).sort((first, second) => first.localeCompare(second, 'es', { sensitivity: 'base' }));
+
+  categories.forEach((category) => {
+    const option = document.createElement('option');
+    option.value = category;
+    option.textContent = category;
+    ideaCategoryFilter.append(option);
+  });
+
+  if (currentValue && !categories.includes(currentValue)) {
+    ideaCategoryFilter.value = '';
+    ideaFilters.category = '';
+  } else if (currentValue) {
+    ideaCategoryFilter.value = currentValue;
+  }
+};
+
+const renderIdeas = () => {
+  if (!ideasGrid) {
+    return;
+  }
+
+  ideasGrid.innerHTML = '';
+
+  const filtered = applyIdeaFilters(ideasData);
+
+  if (!filtered.length) {
+    const empty = document.createElement('p');
+    empty.className = 'idea-card__empty';
+    empty.textContent = ideasData.length
+      ? 'No hay ideas que coincidan con los filtros.'
+      : 'Guarda tus primeras ideas para inspirarte.';
+    ideasGrid.append(empty);
+    return;
+  }
+
+  filtered.forEach((idea) => {
+    ideasGrid.append(createIdeaCard(idea, currentIdeaUserId));
+  });
+};
+
+const handleIdeaFormSubmit = (event) => {
+  event.preventDefault();
+
+  if (!ideaForm) {
+    return;
+  }
+
+  const payload = {
+    title: ideaTitleInput ? ideaTitleInput.value : '',
+    url: ideaUrlInput ? ideaUrlInput.value : '',
+    category: ideaCategoryInput ? ideaCategoryInput.value : '',
+    note: ideaNoteInput ? ideaNoteInput.value : '',
+  };
+
+  const user = getCurrentUser();
+  const uid = currentIdeaUserId || (user && user.uid ? user.uid : null);
+
+  const submission = ideasStore.addIdea(payload, uid);
+
+  ideaForm.reset();
+
+  if (ideaTitleInput) {
+    ideaTitleInput.focus();
+  }
+
+  if (submission && typeof submission.catch === 'function') {
+    submission.catch((error) => {
+      console.error('No se pudo guardar la idea.', error);
+      alert('No se pudo guardar la idea. Inténtalo nuevamente.');
+    });
+  }
+};
+
+const handleIdeaGridClick = (event) => {
+  const target = event.target instanceof HTMLElement ? event.target : null;
+
+  if (!target) {
+    return;
+  }
+
+  const likeButton = target.closest('.idea-card__like');
+  const deleteButton = target.closest('.idea-card__delete');
+  const control = likeButton || deleteButton;
+
+  if (!control) {
+    return;
+  }
+
+  const card = control.closest('.idea-card');
+
+  if (!card) {
+    return;
+  }
+
+  const ideaId = card.dataset.id;
+
+  if (!ideaId) {
+    return;
+  }
+
+  if (likeButton) {
+    if (!currentIdeaUserId) {
+      alert('Esperando autenticación con Firebase. Intenta nuevamente en unos segundos.');
+      return;
+    }
+
+    const isLiked = likeButton.classList.contains('is-liked');
+    const toggle = ideasStore.toggleLike(ideaId, currentIdeaUserId, isLiked);
+
+    if (toggle && typeof toggle.catch === 'function') {
+      toggle.catch((error) => {
+        console.error('No se pudo actualizar el favorito.', error);
+        alert('No se pudo actualizar el favorito. Inténtalo nuevamente.');
+      });
+    }
+
+    return;
+  }
+
+  if (deleteButton) {
+    const confirmed = window.confirm('¿Quieres eliminar esta idea?');
+
+    if (!confirmed) {
+      return;
+    }
+
+    const removal = ideasStore.deleteIdea(ideaId);
+
+    if (removal && typeof removal.catch === 'function') {
+      removal.catch((error) => {
+        console.error('No se pudo eliminar la idea.', error);
+        alert('No se pudo eliminar la idea. Inténtalo nuevamente.');
+      });
+    }
+  }
+};
+
+const initializeIdeasSection = () => {
+  if (!ideaForm || !ideasGrid) {
+    return;
+  }
+
+  ideasStore.subscribe(({ ideas }) => {
+    ideasData = ideas;
+    updateIdeasCategoryFilter();
+    renderIdeas();
+  });
+
+  ideasStore.init();
+
+  ideaForm.addEventListener('submit', handleIdeaFormSubmit);
+
+  if (ideaSearchInput) {
+    ideaSearchInput.addEventListener('input', (event) => {
+      const value = typeof event.target.value === 'string' ? event.target.value : '';
+      ideaFilters.search = value.trim().toLowerCase();
+      renderIdeas();
+    });
+  }
+
+  if (ideaCategoryFilter) {
+    ideaCategoryFilter.addEventListener('change', (event) => {
+      ideaFilters.category = event.target.value;
+      renderIdeas();
+    });
+  }
+
+  ideasGrid.addEventListener('click', handleIdeaGridClick);
+
+  waitForCurrentUser()
+    .then((user) => {
+      currentIdeaUserId = user && user.uid ? user.uid : null;
+      renderIdeas();
+    })
+    .catch((error) => {
+      console.warn('No se pudo obtener el usuario para los likes.', error);
+    });
+};
+
+// Presupuesto
+const budgetTargetForm = document.getElementById('budget-target-form');
+const budgetTargetInput = document.getElementById('budget-target');
+const budgetTargetValue = document.getElementById('budget-target-value');
+const budgetEstimatedValue = document.getElementById('budget-estimated');
+const budgetActualValue = document.getElementById('budget-actual');
+const budgetPaidValue = document.getElementById('budget-paid');
+const budgetPaidPercentValue = document.getElementById('budget-paid-percent');
+const budgetDiffValue = document.getElementById('budget-diff');
+
+const budgetItemForm = document.getElementById('budget-item-form');
+const budgetTitleInput = document.getElementById('budget-title');
+const budgetCategoryInput = document.getElementById('budget-category');
+const budgetEstimateInput = document.getElementById('budget-estimate');
+const budgetActualInput = document.getElementById('budget-actual-input');
+const budgetProviderInput = document.getElementById('budget-provider');
+const budgetDateInput = document.getElementById('budget-date');
+
+const budgetCategoryFilter = document.getElementById('budget-category-filter');
+const budgetPaidFilter = document.getElementById('budget-paid-filter');
+const budgetTableBody = document.getElementById('budget-table-body');
+
+const toAmount = (value) => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Number.parseFloat(value.toFixed(2));
+  }
+
+  if (typeof value === 'string') {
+    const cleaned = value.replace(/,/g, '.');
+    const parsed = Number.parseFloat(cleaned);
+    if (Number.isFinite(parsed)) {
+      return Number.parseFloat(parsed.toFixed(2));
+    }
+  }
+
+  return 0;
+};
+
+const normalizeBudgetItem = (id, record) => {
+  if (!record || typeof record !== 'object') {
+    return null;
+  }
+
+  const title = sanitizeEntityText(record.title);
+
+  if (!title) {
+    return null;
+  }
+
+  const category = sanitizeEntityText(record.category) || 'General';
+  const dueDate = sanitizeEntityText(record.dueDate);
+
+  return {
+    id,
+    title,
+    category,
+    est: toAmount(record.est),
+    act: toAmount(record.act),
+    paid: Boolean(record.paid),
+    dueDate,
+    provider: sanitizeEntityText(record.provider),
+    createdAt: toTimestamp(record.createdAt),
+    updatedAt: toTimestamp(record.updatedAt),
+  };
+};
+
+const getDueDateTimestamp = (value) => {
+  const normalized = normalizeDueDate(value);
+
+  if (!normalized) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const [year, month, day] = normalized.split('-').map((part) => Number.parseInt(part, 10));
+  const date = new Date(year, month - 1, day);
+  return date.getTime();
+};
+
+const mapBudgetItems = (records) =>
+  Object.entries(records ?? {})
+    .map(([id, value]) => normalizeBudgetItem(id, value))
+    .filter((value) => value !== null)
+    .sort((first, second) => {
+      const firstDue = getDueDateTimestamp(first.dueDate);
+      const secondDue = getDueDateTimestamp(second.dueDate);
+
+      if (firstDue !== secondDue) {
+        return firstDue - secondDue;
+      }
+
+      const firstCreated = typeof first.createdAt === 'number' ? first.createdAt : 0;
+      const secondCreated = typeof second.createdAt === 'number' ? second.createdAt : 0;
+
+      return firstCreated - secondCreated;
+    });
+
+const createBudgetStore = () => {
+  let sync = null;
+  let unsubscribe = () => {};
+  let targetValue = 0;
+  let items = [];
+  let rawItems = {};
+  const listeners = new Set();
+
+  const emit = () => {
+    const snapshot = {
+      target: targetValue,
+      items: items.map((item) => ({ ...item })),
+      rawItems: { ...rawItems },
+    };
+    listeners.forEach((listener) => listener(snapshot));
+  };
+
+  const ensureSync = async () => {
+    if (sync) {
+      return sync;
+    }
+
+    const instance = await waitForFirebaseSync();
+    if (!instance) {
+      throw new Error('SYNC_UNAVAILABLE');
+    }
+
+    sync = instance;
+    return sync;
+  };
+
+  const init = () =>
+    ensureSync()
+      .then((instance) => {
+        if (!instance || typeof instance.listenBudget !== 'function') {
+          return;
+        }
+
+        unsubscribe();
+        unsubscribe = () => {};
+
+        try {
+          const stop = instance.listenBudget((data) => {
+            const meta = data && typeof data.meta === 'object' ? data.meta : {};
+            rawItems = data && typeof data.items === 'object' ? data.items : {};
+            items = mapBudgetItems(rawItems);
+
+            const numericTarget = Number.parseFloat(meta.target);
+            targetValue = Number.isFinite(numericTarget) ? numericTarget : 0;
+            emit();
+          });
+
+          unsubscribe = typeof stop === 'function' ? stop : () => {};
+        } catch (error) {
+          console.warn('No se pudo iniciar la escucha del presupuesto.', error);
+        }
+      })
+      .catch((error) => {
+        console.warn('No se pudo iniciar la sincronización del presupuesto.', error);
+      });
+
+  const subscribe = (listener) => {
+    listeners.add(listener);
+    listener({
+      target: targetValue,
+      items: items.map((item) => ({ ...item })),
+      rawItems: { ...rawItems },
+    });
+
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  const setTarget = (value) =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.setBudgetTarget !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.setBudgetTarget(value);
+    });
+
+  const addItem = (payload) =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.addBudgetItem !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.addBudgetItem(payload);
+    });
+
+  const updateItem = (itemId, changes) =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.updateBudgetItem !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.updateBudgetItem(itemId, changes);
+    });
+
+  const deleteItem = (itemId) =>
+    ensureSync().then((instance) => {
+      if (!instance || typeof instance.deleteBudgetItem !== 'function') {
+        throw new Error('SYNC_UNAVAILABLE');
+      }
+
+      return instance.deleteBudgetItem(itemId);
+    });
+
+  const destroy = () => {
+    try {
+      unsubscribe();
+    } catch (error) {
+      console.warn('No se pudo detener la escucha del presupuesto.', error);
+    }
+    unsubscribe = () => {};
+    listeners.clear();
+  };
+
+  const getSnapshot = () => ({
+    target: targetValue,
+    items: items.map((item) => ({ ...item })),
+    rawItems: { ...rawItems },
+  });
+
+  return {
+    init,
+    subscribe,
+    setTarget,
+    addItem,
+    updateItem,
+    deleteItem,
+    destroy,
+    getSnapshot,
+  };
+};
+
+const budgetStore = createBudgetStore();
+
+let budgetState = {
+  target: 0,
+  items: [],
+};
+
+const budgetFilters = {
+  category: '',
+  paid: '',
+};
+
+const currencyFormatter = new Intl.NumberFormat('es-ES', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 2,
+});
+
+const formatCurrency = (value) => {
+  const numeric = typeof value === 'number' && Number.isFinite(value) ? value : 0;
+  return currencyFormatter.format(numeric);
+};
+
+const formatBudgetDate = (value) => {
+  const normalized = normalizeDueDate(value);
+
+  if (!normalized) {
+    return '—';
+  }
+
+  const [year, month, day] = normalized.split('-').map((part) => Number.parseInt(part, 10));
+  const date = new Date(year, month - 1, day);
+  return new Intl.DateTimeFormat('es-ES', { day: '2-digit', month: 'short' }).format(date);
+};
+
+const renderBudgetSummary = () => {
+  const totalEstimated = budgetState.items.reduce(
+    (sum, item) => sum + (Number.isFinite(item.est) ? item.est : 0),
+    0,
+  );
+  const totalActual = budgetState.items.reduce(
+    (sum, item) => sum + (Number.isFinite(item.act) ? item.act : 0),
+    0,
+  );
+  const totalPaid = budgetState.items.reduce(
+    (sum, item) => sum + (item.paid ? (Number.isFinite(item.act) ? item.act : 0) : 0),
+    0,
+  );
+
+  const diff = totalActual - totalEstimated;
+  const paidPercent = totalActual > 0 ? Math.round((totalPaid / totalActual) * 100) : 0;
+
+  if (budgetTargetValue) {
+    budgetTargetValue.textContent = formatCurrency(budgetState.target);
+  }
+
+  if (budgetEstimatedValue) {
+    budgetEstimatedValue.textContent = formatCurrency(totalEstimated);
+  }
+
+  if (budgetActualValue) {
+    budgetActualValue.textContent = formatCurrency(totalActual);
+  }
+
+  if (budgetPaidValue) {
+    budgetPaidValue.textContent = formatCurrency(totalPaid);
+  }
+
+  if (budgetPaidPercentValue) {
+    budgetPaidPercentValue.textContent = `${Math.max(0, Math.min(100, paidPercent))}%`;
+  }
+
+  if (budgetDiffValue) {
+    budgetDiffValue.textContent = formatCurrency(diff);
+    budgetDiffValue.classList.toggle('budget-diff--positive', diff <= 0);
+    budgetDiffValue.classList.toggle('budget-diff--negative', diff > 0);
+  }
+};
+
+const updateBudgetCategoryFilter = () => {
+  if (!budgetCategoryFilter) {
+    return;
+  }
+
+  const currentValue = budgetCategoryFilter.value;
+
+  Array.from(budgetCategoryFilter.options)
+    .slice(1)
+    .forEach((option) => option.remove());
+
+  const categories = Array.from(
+    new Set(budgetState.items.map((item) => item.category).filter((category) => Boolean(category))),
+  ).sort((first, second) => first.localeCompare(second, 'es', { sensitivity: 'base' }));
+
+  categories.forEach((category) => {
+    const option = document.createElement('option');
+    option.value = category;
+    option.textContent = category;
+    budgetCategoryFilter.append(option);
+  });
+
+  if (currentValue && !categories.includes(currentValue)) {
+    budgetCategoryFilter.value = '';
+    budgetFilters.category = '';
+  } else if (currentValue) {
+    budgetCategoryFilter.value = currentValue;
+  }
+};
+
+const applyBudgetFilters = (items) =>
+  items.filter((item) => {
+    if (budgetFilters.category && item.category !== budgetFilters.category) {
+      return false;
+    }
+
+    if (budgetFilters.paid === 'paid' && !item.paid) {
+      return false;
+    }
+
+    if (budgetFilters.paid === 'pending' && item.paid) {
+      return false;
+    }
+
+    return true;
+  });
+
+const createBudgetRow = (item) => {
+  const row = document.createElement('tr');
+  row.dataset.id = item.id;
+
+  const titleCell = document.createElement('td');
+  titleCell.className = 'budget-table__cell budget-table__cell--title';
+  titleCell.textContent = item.title;
+
+  const categoryCell = document.createElement('td');
+  categoryCell.className = 'budget-table__cell';
+  categoryCell.textContent = item.category || 'General';
+
+  const estimatedCell = document.createElement('td');
+  estimatedCell.className = 'budget-table__cell budget-table__cell--number';
+  estimatedCell.textContent = formatCurrency(item.est);
+
+  const actualCell = document.createElement('td');
+  actualCell.className = 'budget-table__cell budget-table__cell--number';
+  const actualInput = document.createElement('input');
+  actualInput.type = 'number';
+  actualInput.className = 'budget-row__actual';
+  actualInput.min = '0';
+  actualInput.step = '0.01';
+  actualInput.value = item.act ? String(item.act) : '';
+  actualInput.setAttribute('aria-label', `Importe real de ${item.title}`);
+  actualCell.append(actualInput);
+
+  const diffCell = document.createElement('td');
+  diffCell.className = 'budget-table__cell budget-table__cell--number budget-diff';
+  const diff = (Number.isFinite(item.act) ? item.act : 0) - (Number.isFinite(item.est) ? item.est : 0);
+  diffCell.textContent = formatCurrency(diff);
+  diffCell.classList.toggle('budget-diff--positive', diff <= 0);
+  diffCell.classList.toggle('budget-diff--negative', diff > 0);
+
+  const paidCell = document.createElement('td');
+  paidCell.className = 'budget-table__cell budget-table__cell--paid';
+  const paidLabel = document.createElement('label');
+  paidLabel.className = 'budget-row__paid-label';
+  const paidCheckbox = document.createElement('input');
+  paidCheckbox.type = 'checkbox';
+  paidCheckbox.className = 'budget-row__paid';
+  paidCheckbox.checked = Boolean(item.paid);
+  paidCheckbox.setAttribute('aria-label', `Marcar ${item.title} como pagado`);
+  const paidText = document.createElement('span');
+  paidText.textContent = 'Pagado';
+  paidLabel.append(paidCheckbox, paidText);
+  paidCell.append(paidLabel);
+
+  const dueCell = document.createElement('td');
+  dueCell.className = 'budget-table__cell';
+  dueCell.textContent = formatBudgetDate(item.dueDate);
+  if (item.dueDate) {
+    dueCell.title = item.dueDate;
+  }
+
+  const providerCell = document.createElement('td');
+  providerCell.className = 'budget-table__cell';
+  providerCell.textContent = item.provider || '—';
+
+  const actionsCell = document.createElement('td');
+  actionsCell.className = 'budget-table__cell budget-table__cell--actions';
+  const deleteButton = document.createElement('button');
+  deleteButton.type = 'button';
+  deleteButton.className = 'budget-row__delete';
+  deleteButton.textContent = 'Eliminar';
+  deleteButton.setAttribute('aria-label', `Eliminar gasto: ${item.title}`);
+  actionsCell.append(deleteButton);
+
+  row.append(
+    titleCell,
+    categoryCell,
+    estimatedCell,
+    actualCell,
+    diffCell,
+    paidCell,
+    dueCell,
+    providerCell,
+    actionsCell,
+  );
+
+  return row;
+};
+
+const renderBudgetTable = () => {
+  if (!budgetTableBody) {
+    return;
+  }
+
+  budgetTableBody.innerHTML = '';
+
+  const filtered = applyBudgetFilters(budgetState.items);
+
+  if (!filtered.length) {
+    const emptyRow = document.createElement('tr');
+    emptyRow.className = 'budget-table__empty';
+
+    const cell = document.createElement('td');
+    cell.colSpan = 9;
+    cell.textContent = budgetState.items.length
+      ? 'No hay elementos que coincidan con los filtros.'
+      : 'Agrega tu primer gasto para seguir el presupuesto.';
+
+    emptyRow.append(cell);
+    budgetTableBody.append(emptyRow);
+    return;
+  }
+
+  filtered.forEach((item) => {
+    budgetTableBody.append(createBudgetRow(item));
+  });
+};
+
+const handleBudgetTargetSubmit = (event) => {
+  event.preventDefault();
+
+  const value = budgetTargetInput ? Number.parseFloat(budgetTargetInput.value) || 0 : 0;
+  const submission = budgetStore.setTarget(value);
+
+  if (submission && typeof submission.catch === 'function') {
+    submission.catch((error) => {
+      console.error('No se pudo actualizar el objetivo de presupuesto.', error);
+      alert('No se pudo actualizar el objetivo. Inténtalo nuevamente.');
+    });
+  }
+};
+
+const handleBudgetItemSubmit = (event) => {
+  event.preventDefault();
+
+  if (!budgetItemForm) {
+    return;
+  }
+
+  const payload = {
+    title: budgetTitleInput ? budgetTitleInput.value : '',
+    category: budgetCategoryInput ? budgetCategoryInput.value : '',
+    est: budgetEstimateInput ? budgetEstimateInput.value : 0,
+    act: budgetActualInput ? budgetActualInput.value : 0,
+    provider: budgetProviderInput ? budgetProviderInput.value : '',
+    dueDate: budgetDateInput ? budgetDateInput.value : '',
+  };
+
+  const submission = budgetStore.addItem(payload);
+
+  budgetItemForm.reset();
+
+  if (budgetTitleInput) {
+    budgetTitleInput.focus();
+  }
+
+  if (submission && typeof submission.catch === 'function') {
+    submission.catch((error) => {
+      console.error('No se pudo guardar el gasto.', error);
+      alert('No se pudo guardar el gasto. Inténtalo nuevamente.');
+    });
+  }
+};
+
+const handleBudgetCategoryFilterChange = (event) => {
+  budgetFilters.category = event.target.value;
+  renderBudgetTable();
+};
+
+const handleBudgetPaidFilterChange = (event) => {
+  budgetFilters.paid = event.target.value;
+  renderBudgetTable();
+};
+
+const handleBudgetTableChange = (event) => {
+  const target = event.target instanceof HTMLElement ? event.target : null;
+
+  if (!target) {
+    return;
+  }
+
+  const row = target.closest('tr');
+
+  if (!row) {
+    return;
+  }
+
+  const itemId = row.dataset.id;
+
+  if (!itemId) {
+    return;
+  }
+
+  if (target.matches('.budget-row__actual')) {
+    const update = budgetStore.updateItem(itemId, { act: target.value });
+
+    if (update && typeof update.catch === 'function') {
+      update.catch((error) => {
+        console.error('No se pudo actualizar el importe real.', error);
+        alert('No se pudo actualizar el importe real. Inténtalo nuevamente.');
+      });
+    }
+
+    return;
+  }
+
+  if (target.matches('.budget-row__paid')) {
+    const update = budgetStore.updateItem(itemId, { paid: target.checked });
+
+    if (update && typeof update.catch === 'function') {
+      update.catch((error) => {
+        console.error('No se pudo actualizar el estado de pago.', error);
+        alert('No se pudo actualizar el estado de pago. Inténtalo nuevamente.');
+      });
+    }
+  }
+};
+
+const handleBudgetTableClick = (event) => {
+  const target = event.target instanceof HTMLElement ? event.target : null;
+
+  if (!target) {
+    return;
+  }
+
+  const deleteButton = target.closest('.budget-row__delete');
+
+  if (!deleteButton) {
+    return;
+  }
+
+  const row = deleteButton.closest('tr');
+
+  if (!row) {
+    return;
+  }
+
+  const itemId = row.dataset.id;
+
+  if (!itemId) {
+    return;
+  }
+
+  const confirmed = window.confirm('¿Quieres eliminar este gasto?');
+
+  if (!confirmed) {
+    return;
+  }
+
+  const removal = budgetStore.deleteItem(itemId);
+
+  if (removal && typeof removal.catch === 'function') {
+    removal.catch((error) => {
+      console.error('No se pudo eliminar el gasto.', error);
+      alert('No se pudo eliminar el gasto. Inténtalo nuevamente.');
+    });
+  }
+};
+
+const initializeBudgetSection = () => {
+  if (!budgetTargetForm || !budgetItemForm || !budgetTableBody) {
+    return;
+  }
+
+  budgetStore.subscribe((snapshot) => {
+    budgetState = {
+      target: Number.isFinite(snapshot.target) ? snapshot.target : 0,
+      items: snapshot.items,
+    };
+
+    renderBudgetSummary();
+    updateBudgetCategoryFilter();
+    renderBudgetTable();
+  });
+
+  budgetStore.init();
+
+  budgetTargetForm.addEventListener('submit', handleBudgetTargetSubmit);
+  budgetItemForm.addEventListener('submit', handleBudgetItemSubmit);
+
+  if (budgetCategoryFilter) {
+    budgetCategoryFilter.addEventListener('change', handleBudgetCategoryFilterChange);
+  }
+
+  if (budgetPaidFilter) {
+    budgetPaidFilter.addEventListener('change', handleBudgetPaidFilterChange);
+  }
+
+  budgetTableBody.addEventListener('change', handleBudgetTableChange);
+  budgetTableBody.addEventListener('click', handleBudgetTableClick);
+};
+
 const initializeAppState = async () => {
   store.subscribe((nextTasks) => {
     tasks = nextTasks;
@@ -724,6 +2549,15 @@ const initializeAppState = async () => {
 };
 
 initializeAppState();
+initializeGuestSection();
+initializeIdeasSection();
+initializeBudgetSection();
 selectTab('checklist');
+
+window.addEventListener('beforeunload', () => {
+  guestsStore.destroy();
+  ideasStore.destroy();
+  budgetStore.destroy();
+});
 
 

--- a/index.html
+++ b/index.html
@@ -153,32 +153,78 @@
           <section id="ideas" class="tab-content" role="tabpanel" aria-labelledby="ideas-tab">
             <div class="panel">
               <header class="panel__header">
-                <h2 class="panel__title">Ideas y inspiracion</h2>
+                <h2 class="panel__title">Ideas e inspiración</h2>
                 <p class="panel__subtitle">
-                  Galeria para anotar estilos, colores y proveedores favoritos.
+                  Guarda referencias de decoración, proveedores y detalles especiales.
                 </p>
               </header>
 
-              <div class="gallery">
-                <article class="gallery__card">
-                  <h3 class="gallery__title">Decoracion</h3>
-                  <p class="gallery__text">
-                    Guarda links a arreglos florales, seating charts o invitaciones que te gusten.
-                  </p>
-                </article>
-                <article class="gallery__card">
-                  <h3 class="gallery__title">Momentos clave</h3>
-                  <p class="gallery__text">
-                    Escribe ideas para la ceremonia, discursos o una cancion especial para el primer baile.
-                  </p>
-                </article>
-                <article class="gallery__card">
-                  <h3 class="gallery__title">Lista de deseos</h3>
-                  <p class="gallery__text">
-                    Añade referencias para recuerdos, detalles de mesas o sorpresas para invitados.
-                  </p>
-                </article>
+              <form id="idea-form" class="form-grid" autocomplete="off">
+                <div class="form-field form-field--full">
+                  <label class="form-label" for="idea-title">Título</label>
+                  <input
+                    id="idea-title"
+                    class="form-control"
+                    type="text"
+                    placeholder="Centro de mesa, invitaciones…"
+                    required
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="idea-url">URL</label>
+                  <input
+                    id="idea-url"
+                    class="form-control"
+                    type="url"
+                    placeholder="https://"
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="idea-category">Categoría</label>
+                  <input
+                    id="idea-category"
+                    class="form-control"
+                    type="text"
+                    placeholder="Decoración, música, viaje…"
+                    required
+                  />
+                </div>
+
+                <div class="form-field form-field--full">
+                  <label class="form-label" for="idea-note">Nota</label>
+                  <textarea
+                    id="idea-note"
+                    class="form-control form-control--textarea"
+                    rows="2"
+                    placeholder="Detalles para recordar"
+                  ></textarea>
+                </div>
+
+                <button class="button form-submit" type="submit">Guardar idea</button>
+              </form>
+
+              <div class="ideas-toolbar">
+                <div class="ideas-filter">
+                  <label class="form-label" for="idea-search">Buscar</label>
+                  <input
+                    id="idea-search"
+                    class="form-control"
+                    type="search"
+                    placeholder="Buscar por título"
+                  />
+                </div>
+
+                <div class="ideas-filter">
+                  <label class="form-label" for="idea-category-filter">Categoría</label>
+                  <select id="idea-category-filter" class="form-control">
+                    <option value="">Todas</option>
+                  </select>
+                </div>
               </div>
+
+              <div id="ideas-grid" class="ideas-grid" aria-live="polite"></div>
             </div>
           </section>
 
@@ -187,15 +233,145 @@
               <header class="panel__header">
                 <h2 class="panel__title">Invitados</h2>
                 <p class="panel__subtitle">
-                  Prepara una lista maestra y anota confirmaciones o necesidades especiales.
+                  Gestiona confirmaciones, acompañantes y notas especiales en tiempo real.
                 </p>
               </header>
 
-              <div class="info-card">
-                <p class="info-card__line">Crea grupos por familias, amigos y trabajo.</p>
-                <p class="info-card__line">Marca asistentes confirmados y acompanantes.</p>
-                <p class="info-card__line">Exporta la lista para coordinar las mesas.</p>
+              <form id="guest-form" class="form-grid" autocomplete="off">
+                <div class="form-field form-field--full">
+                  <label class="form-label" for="guest-name">Nombre</label>
+                  <input
+                    id="guest-name"
+                    class="form-control"
+                    type="text"
+                    placeholder="Nombre completo"
+                    required
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="guest-side">Lado</label>
+                  <select id="guest-side" class="form-control" required>
+                    <option value="novia">Novia</option>
+                    <option value="novio">Novio</option>
+                    <option value="ambos">Ambos</option>
+                  </select>
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="guest-group">Grupo</label>
+                  <input
+                    id="guest-group"
+                    class="form-control"
+                    type="text"
+                    placeholder="Familia, amigos…"
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="guest-rsvp">RSVP</label>
+                  <select id="guest-rsvp" class="form-control">
+                    <option value="pending">Pendiente</option>
+                    <option value="yes">Confirmado</option>
+                    <option value="no">Rechazado</option>
+                  </select>
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="guest-plus">Acompañantes</label>
+                  <input
+                    id="guest-plus"
+                    class="form-control"
+                    type="number"
+                    min="0"
+                    step="1"
+                    value="0"
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="guest-contact">Contacto</label>
+                  <input
+                    id="guest-contact"
+                    class="form-control"
+                    type="text"
+                    placeholder="Correo o teléfono"
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="guest-dietary">Restricciones</label>
+                  <input
+                    id="guest-dietary"
+                    class="form-control"
+                    type="text"
+                    placeholder="Sin gluten, vegetariano…"
+                  />
+                </div>
+
+                <div class="form-field form-field--full">
+                  <label class="form-label" for="guest-notes">Notas</label>
+                  <textarea
+                    id="guest-notes"
+                    class="form-control form-control--textarea"
+                    rows="2"
+                    placeholder="Comentarios extra"
+                  ></textarea>
+                </div>
+
+                <button class="button form-submit" type="submit">Agregar invitado</button>
+              </form>
+
+              <div class="guest-summary" aria-live="polite">
+                <div class="summary__item">
+                  <span class="summary__label">Invitados</span>
+                  <strong id="guest-total" class="summary__value">0</strong>
+                </div>
+                <div class="summary__item">
+                  <span class="summary__label">Confirmados</span>
+                  <strong id="guest-confirmed" class="summary__value">0</strong>
+                </div>
+                <div class="summary__item">
+                  <span class="summary__label">Pendientes</span>
+                  <strong id="guest-pending" class="summary__value">0</strong>
+                </div>
+                <div class="summary__item">
+                  <span class="summary__label">Personas totales</span>
+                  <strong id="guest-people" class="summary__value">0</strong>
+                </div>
               </div>
+
+              <div class="guest-toolbar">
+                <div class="guest-filter">
+                  <label class="form-label" for="guest-search">Buscar</label>
+                  <input
+                    id="guest-search"
+                    class="form-control"
+                    type="search"
+                    placeholder="Buscar por nombre"
+                  />
+                </div>
+                <div class="guest-filter">
+                  <label class="form-label" for="guest-rsvp-filter">RSVP</label>
+                  <select id="guest-rsvp-filter" class="form-control">
+                    <option value="">Todos</option>
+                    <option value="yes">Confirmados</option>
+                    <option value="pending">Pendientes</option>
+                    <option value="no">Rechazados</option>
+                  </select>
+                </div>
+                <div class="guest-filter">
+                  <label class="form-label" for="guest-group-filter">Grupo</label>
+                  <select id="guest-group-filter" class="form-control">
+                    <option value="">Todos</option>
+                  </select>
+                </div>
+                <button id="guest-export" class="button button--ghost" type="button">
+                  Exportar CSV
+                </button>
+              </div>
+
+              <ul id="guest-list" class="guest-list" aria-live="polite"></ul>
             </div>
           </section>
 
@@ -204,29 +380,153 @@
               <header class="panel__header">
                 <h2 class="panel__title">Presupuesto</h2>
                 <p class="panel__subtitle">
-                  Establece tu presupuesto objetivo y controla gastos estimados y reales.
+                  Define tu objetivo, sigue gastos estimados y reales y controla pagos.
                 </p>
               </header>
 
-              <div class="budget-grid">
-                <article class="budget-card">
-                  <h3 class="budget-card__title">Vista general</h3>
-                  <p class="budget-card__text">
-                    Divide el presupuesto entre catering, musica, fotografia y otros rubros clave.
-                  </p>
-                </article>
-                <article class="budget-card">
-                  <h3 class="budget-card__title">Control mensual</h3>
-                  <p class="budget-card__text">
-                    Haz seguimiento de pagos y fechas limites para evitar sorpresas de ultimo momento.
-                  </p>
-                </article>
-                <article class="budget-card">
-                  <h3 class="budget-card__title">Ahorros e imprevistos</h3>
-                  <p class="budget-card__text">
-                    Reserva un porcentaje para detalles de ultima hora o mejoras de experiencia.
-                  </p>
-                </article>
+              <form id="budget-target-form" class="budget-target" autocomplete="off">
+                <label class="form-label" for="budget-target">Objetivo general</label>
+                <div class="budget-target__controls">
+                  <input
+                    id="budget-target"
+                    class="form-control"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    placeholder="0"
+                  />
+                  <button class="button button--compact" type="submit">Guardar objetivo</button>
+                </div>
+              </form>
+
+              <div class="budget-summary" aria-live="polite">
+                <div class="budget-summary__item">
+                  <span class="summary__label">Objetivo</span>
+                  <strong id="budget-target-value" class="summary__value">0</strong>
+                </div>
+                <div class="budget-summary__item">
+                  <span class="summary__label">Estimado</span>
+                  <strong id="budget-estimated" class="summary__value">0</strong>
+                </div>
+                <div class="budget-summary__item">
+                  <span class="summary__label">Real</span>
+                  <strong id="budget-actual" class="summary__value">0</strong>
+                </div>
+                <div class="budget-summary__item">
+                  <span class="summary__label">Pagado</span>
+                  <strong id="budget-paid" class="summary__value">0</strong>
+                </div>
+                <div class="budget-summary__item">
+                  <span class="summary__label">% Pagado</span>
+                  <strong id="budget-paid-percent" class="summary__value">0%</strong>
+                </div>
+                <div class="budget-summary__item">
+                  <span class="summary__label">Diferencia</span>
+                  <strong id="budget-diff" class="summary__value">0</strong>
+                </div>
+              </div>
+
+              <form id="budget-item-form" class="form-grid budget-item-form" autocomplete="off">
+                <div class="form-field form-field--full">
+                  <label class="form-label" for="budget-title">Concepto</label>
+                  <input
+                    id="budget-title"
+                    class="form-control"
+                    type="text"
+                    placeholder="Catering, música, flores…"
+                    required
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="budget-category">Categoría</label>
+                  <input
+                    id="budget-category"
+                    class="form-control"
+                    type="text"
+                    placeholder="Catering, foto…"
+                    required
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="budget-estimate">Estimado</label>
+                  <input
+                    id="budget-estimate"
+                    class="form-control"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                    required
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="budget-actual-input">Real</label>
+                  <input
+                    id="budget-actual-input"
+                    class="form-control"
+                    type="number"
+                    min="0"
+                    step="0.01"
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="budget-provider">Proveedor</label>
+                  <input
+                    id="budget-provider"
+                    class="form-control"
+                    type="text"
+                    placeholder="Nombre o contacto"
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="budget-date">Fecha</label>
+                  <input id="budget-date" class="form-control" type="date" />
+                </div>
+
+                <button class="button form-submit" type="submit">Agregar gasto</button>
+              </form>
+
+              <div class="budget-toolbar">
+                <div class="budget-filter">
+                  <label class="form-label" for="budget-category-filter">Categoría</label>
+                  <select id="budget-category-filter" class="form-control">
+                    <option value="">Todas</option>
+                  </select>
+                </div>
+                <div class="budget-filter">
+                  <label class="form-label" for="budget-paid-filter">Pagado</label>
+                  <select id="budget-paid-filter" class="form-control">
+                    <option value="">Todos</option>
+                    <option value="paid">Pagados</option>
+                    <option value="pending">Pendientes</option>
+                  </select>
+                </div>
+              </div>
+
+              <div class="table-wrapper">
+                <table class="budget-table" aria-describedby="presupuesto-tab">
+                  <thead>
+                    <tr>
+                      <th scope="col">Concepto</th>
+                      <th scope="col">Categoría</th>
+                      <th scope="col">Estimado</th>
+                      <th scope="col">Real</th>
+                      <th scope="col">
+                        <span aria-hidden="true">Δ</span>
+                        <span class="visually-hidden">Diferencia</span>
+                      </th>
+                      <th scope="col">Pagado</th>
+                      <th scope="col">Fecha</th>
+                      <th scope="col">Proveedor</th>
+                      <th scope="col" class="visually-hidden">Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody id="budget-table-body"></tbody>
+                </table>
               </div>
             </div>
           </section>
@@ -278,6 +578,11 @@
       const db = getDatabase(app);
       const ROOM = window.DEFAULT_ROOM_ID || "andrea-boda";
       const tasksPath = `rooms/${ROOM}/tasks`;
+      const guestsPath = `rooms/${ROOM}/guests`;
+      const ideasPath = `rooms/${ROOM}/ideas`;
+      const budgetPath = `rooms/${ROOM}/budget`;
+      const budgetMetaPath = `${budgetPath}/meta`;
+      const budgetItemsPath = `${budgetPath}/items`;
 
       function ensureSync() {
         if (!window.ENABLE_SYNC) {
@@ -430,11 +735,547 @@
         }
       }
 
+      const RSVP_VALUES = new Set(["pending", "yes", "no"]);
+      const SIDE_VALUES = new Set(["novia", "novio", "ambos"]);
+
+      const sanitizeText = (value) =>
+        typeof value === "string" ? value.trim() : typeof value === "number" ? String(value).trim() : "";
+
+      const normalizePlusOnes = (value) => {
+        if (typeof value === "number" && Number.isFinite(value)) {
+          return Math.max(0, Math.trunc(value));
+        }
+
+        if (typeof value === "string") {
+          const parsed = Number.parseInt(value, 10);
+          if (Number.isFinite(parsed)) {
+            return Math.max(0, parsed);
+          }
+        }
+
+        return 0;
+      };
+
+      const normalizeRsvp = (value) => (RSVP_VALUES.has(value) ? value : "pending");
+
+      const normalizeSide = (value) => (SIDE_VALUES.has(value) ? value : "ambos");
+
+      const toTimestampValue = (value, fallback) =>
+        typeof value === "number" && Number.isFinite(value) ? value : fallback;
+
+      export function listenGuests(callback) {
+        if (!window.ENABLE_SYNC) {
+          console.warn("La sincronización remota está desactivada.");
+          return () => {};
+        }
+
+        let unsubscribe = () => {};
+
+        waitForAuth()
+          .then(() => {
+            if (!window.ENABLE_SYNC) {
+              console.warn("La sincronización remota está desactivada.");
+              return;
+            }
+
+            const guestsRef = ref(db, guestsPath);
+            unsubscribe = onValue(
+              guestsRef,
+              (snapshot) => {
+                const value = snapshot.val() ?? {};
+                callback(value);
+              },
+              (error) => {
+                console.error("Error al escuchar cambios en invitados.", error);
+              },
+            );
+          })
+          .catch((error) => {
+            console.error("No se pudo iniciar la escucha de invitados.", error);
+          });
+
+        return () => {
+          if (typeof unsubscribe === "function") {
+            unsubscribe();
+          }
+        };
+      }
+
+      export async function addGuest(guest) {
+        await waitForAuth();
+        ensureSync();
+
+        const guestsRef = ref(db, guestsPath);
+        const now = Date.now();
+        const currentUser = auth.currentUser;
+        const name = sanitizeText(guest?.name);
+
+        if (!name) {
+          throw new Error("NAME_REQUIRED");
+        }
+
+        const payload = {
+          name,
+          side: normalizeSide(guest?.side),
+          group: sanitizeText(guest?.group),
+          rsvp: normalizeRsvp(guest?.rsvp),
+          plusOnes: normalizePlusOnes(guest?.plusOnes),
+          dietary: sanitizeText(guest?.dietary),
+          notes: sanitizeText(guest?.notes),
+          contact: sanitizeText(guest?.contact),
+          createdAt: toTimestampValue(guest?.createdAt, now),
+          updatedAt: toTimestampValue(guest?.updatedAt, now),
+          createdBy:
+            sanitizeText(guest?.createdBy) || (currentUser && currentUser.uid ? currentUser.uid : null),
+        };
+
+        try {
+          await push(guestsRef, payload);
+        } catch (error) {
+          console.error("No se pudo crear el invitado en Firebase.", error);
+          throw error;
+        }
+      }
+
+      export async function updateGuest(guestId, changes) {
+        await waitForAuth();
+        ensureSync();
+
+        const guestRef = ref(db, `${guestsPath}/${guestId}`);
+        const updatePayload = {};
+
+        if (typeof changes?.name === "string") {
+          const trimmed = changes.name.trim();
+          if (trimmed) {
+            updatePayload.name = trimmed;
+          }
+        }
+
+        if (typeof changes?.group === "string") {
+          updatePayload.group = changes.group.trim();
+        }
+
+        if (typeof changes?.contact === "string") {
+          updatePayload.contact = changes.contact.trim();
+        }
+
+        if (typeof changes?.dietary === "string") {
+          updatePayload.dietary = changes.dietary.trim();
+        }
+
+        if (typeof changes?.notes === "string") {
+          updatePayload.notes = changes.notes.trim();
+        }
+
+        if (typeof changes?.side === "string") {
+          updatePayload.side = normalizeSide(changes.side);
+        }
+
+        if (typeof changes?.rsvp === "string") {
+          updatePayload.rsvp = normalizeRsvp(changes.rsvp);
+        }
+
+        if (Object.prototype.hasOwnProperty.call(changes ?? {}, "plusOnes")) {
+          updatePayload.plusOnes = normalizePlusOnes(changes.plusOnes);
+        }
+
+        updatePayload.updatedAt = Date.now();
+
+        try {
+          await update(guestRef, updatePayload);
+        } catch (error) {
+          console.error("No se pudo actualizar el invitado en Firebase.", error);
+          throw error;
+        }
+      }
+
+      export async function deleteGuest(guestId) {
+        await waitForAuth();
+        ensureSync();
+
+        const guestRef = ref(db, `${guestsPath}/${guestId}`);
+
+        try {
+          await remove(guestRef);
+        } catch (error) {
+          console.error("No se pudo eliminar el invitado en Firebase.", error);
+          throw error;
+        }
+      }
+
+      const escapeCsvCell = (value) => {
+        if (value === null || value === undefined) {
+          return "";
+        }
+
+        const stringValue = String(value).replace(/[\r\n]+/g, " ").trim();
+        if (stringValue === "") {
+          return "";
+        }
+
+        if (/[",;]/.test(stringValue)) {
+          return `"${stringValue.replace(/"/g, '""')}"`;
+        }
+
+        return stringValue;
+      };
+
+      const formatCsvDate = (timestamp) => {
+        if (typeof timestamp !== "number" || !Number.isFinite(timestamp)) {
+          return "";
+        }
+
+        try {
+          return new Date(timestamp).toISOString();
+        } catch (error) {
+          return "";
+        }
+      };
+
+      export function exportGuestsCSV(guestsObj) {
+        const headers = [
+          "ID",
+          "Nombre",
+          "Lado",
+          "Grupo",
+          "RSVP",
+          "Acompañantes",
+          "Personas totales",
+          "Restricciones",
+          "Notas",
+          "Contacto",
+          "Creado",
+          "Actualizado",
+          "Creado por",
+        ];
+
+        const rows = [headers];
+
+        if (guestsObj && typeof guestsObj === "object") {
+          Object.entries(guestsObj).forEach(([id, record]) => {
+            if (!record || typeof record !== "object") {
+              return;
+            }
+
+            const plusOnes = normalizePlusOnes(record.plusOnes);
+            const totalPeople = 1 + plusOnes;
+
+            rows.push([
+              id,
+              sanitizeText(record.name),
+              normalizeSide(record.side),
+              sanitizeText(record.group),
+              normalizeRsvp(record.rsvp),
+              plusOnes,
+              totalPeople,
+              sanitizeText(record.dietary),
+              sanitizeText(record.notes),
+              sanitizeText(record.contact),
+              formatCsvDate(record.createdAt),
+              formatCsvDate(record.updatedAt),
+              sanitizeText(record.createdBy),
+            ]);
+          });
+        }
+
+        return rows.map((row) => row.map((cell) => escapeCsvCell(cell)).join(",")).join("\n");
+      }
+
+      export function listenIdeas(callback) {
+        if (!window.ENABLE_SYNC) {
+          console.warn("La sincronización remota está desactivada.");
+          return () => {};
+        }
+
+        let unsubscribe = () => {};
+
+        waitForAuth()
+          .then(() => {
+            if (!window.ENABLE_SYNC) {
+              console.warn("La sincronización remota está desactivada.");
+              return;
+            }
+
+            const ideasRef = ref(db, ideasPath);
+            unsubscribe = onValue(
+              ideasRef,
+              (snapshot) => {
+                const value = snapshot.val() ?? {};
+                callback(value);
+              },
+              (error) => {
+                console.error("Error al escuchar cambios en ideas.", error);
+              },
+            );
+          })
+          .catch((error) => {
+            console.error("No se pudo iniciar la escucha de ideas.", error);
+          });
+
+        return () => {
+          if (typeof unsubscribe === "function") {
+            unsubscribe();
+          }
+        };
+      }
+
+      export async function addIdea(idea, uid) {
+        await waitForAuth();
+        ensureSync();
+
+        const ideasRef = ref(db, ideasPath);
+        const now = Date.now();
+        const currentUser = auth.currentUser;
+        const title = sanitizeText(idea?.title);
+
+        if (!title) {
+          throw new Error("TITLE_REQUIRED");
+        }
+
+        const urlValue = sanitizeText(idea?.url);
+
+        const payload = {
+          title,
+          url: urlValue || "",
+          category: sanitizeText(idea?.category) || "Sin categoría",
+          note: sanitizeText(idea?.note),
+          likes: idea?.likes && typeof idea.likes === "object" ? idea.likes : {},
+          createdAt: toTimestampValue(idea?.createdAt, now),
+          updatedAt: toTimestampValue(idea?.updatedAt, now),
+          createdBy:
+            sanitizeText(idea?.createdBy) || uid || (currentUser && currentUser.uid ? currentUser.uid : null),
+        };
+
+        try {
+          await push(ideasRef, payload);
+        } catch (error) {
+          console.error("No se pudo crear la idea en Firebase.", error);
+          throw error;
+        }
+      }
+
+      export async function toggleLike(ideaId, uid, isLiked) {
+        await waitForAuth();
+        ensureSync();
+
+        if (!ideaId || !uid) {
+          throw new Error("LIKE_DATA_MISSING");
+        }
+
+        const ideaRef = ref(db, `${ideasPath}/${ideaId}`);
+        const updates = { updatedAt: Date.now() };
+
+        updates[`likes/${uid}`] = isLiked ? null : true;
+
+        try {
+          await update(ideaRef, updates);
+        } catch (error) {
+          console.error("No se pudo actualizar el like en Firebase.", error);
+          throw error;
+        }
+      }
+
+      export async function deleteIdea(ideaId) {
+        await waitForAuth();
+        ensureSync();
+
+        const ideaRef = ref(db, `${ideasPath}/${ideaId}`);
+
+        try {
+          await remove(ideaRef);
+        } catch (error) {
+          console.error("No se pudo eliminar la idea en Firebase.", error);
+          throw error;
+        }
+      }
+
+      export function listenBudget(callback) {
+        if (!window.ENABLE_SYNC) {
+          console.warn("La sincronización remota está desactivada.");
+          return () => {};
+        }
+
+        let unsubscribe = () => {};
+
+        waitForAuth()
+          .then(() => {
+            if (!window.ENABLE_SYNC) {
+              console.warn("La sincronización remota está desactivada.");
+              return;
+            }
+
+            const budgetRef = ref(db, budgetPath);
+            unsubscribe = onValue(
+              budgetRef,
+              (snapshot) => {
+                const value = snapshot.val() ?? {};
+                const meta = value.meta ?? {};
+                const items = value.items ?? {};
+                callback({ meta, items });
+              },
+              (error) => {
+                console.error("Error al escuchar cambios en presupuesto.", error);
+              },
+            );
+          })
+          .catch((error) => {
+            console.error("No se pudo iniciar la escucha de presupuesto.", error);
+          });
+
+        return () => {
+          if (typeof unsubscribe === "function") {
+            unsubscribe();
+          }
+        };
+      }
+
+      const normalizeAmount = (value) => {
+        if (typeof value === "number" && Number.isFinite(value)) {
+          return Number.parseFloat(value.toFixed(2));
+        }
+
+        if (typeof value === "string") {
+          const cleaned = value.replace(/,/g, ".");
+          const parsed = Number.parseFloat(cleaned);
+          if (Number.isFinite(parsed)) {
+            return Number.parseFloat(parsed.toFixed(2));
+          }
+        }
+
+        return 0;
+      };
+
+      export async function setBudgetTarget(target) {
+        await waitForAuth();
+        ensureSync();
+
+        const value = normalizeAmount(target);
+        const payload = { target: value, updatedAt: Date.now() };
+
+        try {
+          await update(ref(db, budgetMetaPath), payload);
+        } catch (error) {
+          console.error("No se pudo actualizar el objetivo de presupuesto en Firebase.", error);
+          throw error;
+        }
+      }
+
+      export async function addBudgetItem(item) {
+        await waitForAuth();
+        ensureSync();
+
+        const itemsRef = ref(db, budgetItemsPath);
+        const now = Date.now();
+        const currentUser = auth.currentUser;
+        const title = sanitizeText(item?.title);
+
+        if (!title) {
+          throw new Error("TITLE_REQUIRED");
+        }
+
+        const payload = {
+          title,
+          category: sanitizeText(item?.category) || "General",
+          est: normalizeAmount(item?.est),
+          act: normalizeAmount(item?.act),
+          paid: Boolean(item?.paid),
+          dueDate: sanitizeText(item?.dueDate),
+          provider: sanitizeText(item?.provider),
+          createdAt: toTimestampValue(item?.createdAt, now),
+          updatedAt: toTimestampValue(item?.updatedAt, now),
+          createdBy:
+            sanitizeText(item?.createdBy) || (currentUser && currentUser.uid ? currentUser.uid : null),
+        };
+
+        try {
+          await push(itemsRef, payload);
+        } catch (error) {
+          console.error("No se pudo crear el gasto en Firebase.", error);
+          throw error;
+        }
+      }
+
+      export async function updateBudgetItem(itemId, changes) {
+        await waitForAuth();
+        ensureSync();
+
+        const itemRef = ref(db, `${budgetItemsPath}/${itemId}`);
+        const payload = { updatedAt: Date.now() };
+
+        if (typeof changes?.title === "string" && changes.title.trim()) {
+          payload.title = changes.title.trim();
+        }
+
+        if (typeof changes?.category === "string") {
+          payload.category = changes.category.trim();
+        }
+
+        if (Object.prototype.hasOwnProperty.call(changes ?? {}, "est")) {
+          payload.est = normalizeAmount(changes.est);
+        }
+
+        if (Object.prototype.hasOwnProperty.call(changes ?? {}, "act")) {
+          payload.act = normalizeAmount(changes.act);
+        }
+
+        if (Object.prototype.hasOwnProperty.call(changes ?? {}, "paid")) {
+          payload.paid = Boolean(changes.paid);
+        }
+
+        if (typeof changes?.dueDate === "string") {
+          payload.dueDate = changes.dueDate.trim();
+        }
+
+        if (typeof changes?.provider === "string") {
+          payload.provider = changes.provider.trim();
+        }
+
+        try {
+          await update(itemRef, payload);
+        } catch (error) {
+          console.error("No se pudo actualizar el gasto en Firebase.", error);
+          throw error;
+        }
+      }
+
+      export async function deleteBudgetItem(itemId) {
+        await waitForAuth();
+        ensureSync();
+
+        const itemRef = ref(db, `${budgetItemsPath}/${itemId}`);
+
+        try {
+          await remove(itemRef);
+        } catch (error) {
+          console.error("No se pudo eliminar el gasto en Firebase.", error);
+          throw error;
+        }
+      }
+
       window.FirebaseSync = {
         listenTasks,
         addTask,
         toggleTask,
         deleteTask,
+        listenGuests,
+        addGuest,
+        updateGuest,
+        deleteGuest,
+        exportGuestsCSV,
+        listenIdeas,
+        addIdea,
+        toggleLike,
+        deleteIdea,
+        listenBudget,
+        setBudgetTarget,
+        addBudgetItem,
+        updateBudgetItem,
+        deleteBudgetItem,
+      };
+
+      window.FirebaseSession = {
+        waitForAuth,
+        getCurrentUser: () => auth.currentUser,
       };
 
       if (typeof window !== "undefined" && typeof window.dispatchEvent === "function") {

--- a/style.css
+++ b/style.css
@@ -635,3 +635,433 @@ body {
   }
 }
 
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: end;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(98, 86, 255, 0.12);
+}
+
+.form-field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.form-field--full {
+  grid-column: 1 / -1;
+}
+
+.form-label,
+.guest-card__field-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.form-control,
+.guest-card__rsvp,
+.guest-card__plus,
+.guest-card__contact,
+.guest-card__dietary,
+.guest-card__notes,
+.budget-row__actual {
+  width: 100%;
+  padding: 0.7rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(98, 86, 255, 0.2);
+  font: inherit;
+  color: var(--text-primary);
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-control:focus-visible,
+.guest-card__rsvp:focus-visible,
+.guest-card__plus:focus-visible,
+.guest-card__contact:focus-visible,
+.guest-card__dietary:focus-visible,
+.guest-card__notes:focus-visible,
+.budget-row__actual:focus-visible {
+  outline: none;
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(98, 86, 255, 0.2);
+}
+
+.form-control--textarea,
+.guest-card__notes {
+  min-height: 96px;
+  resize: vertical;
+}
+
+.form-submit {
+  align-self: end;
+  min-height: 52px;
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--brand-dark);
+  border: 1px solid rgba(98, 86, 255, 0.4);
+  box-shadow: none;
+}
+
+.button--ghost:hover {
+  transform: none;
+  box-shadow: none;
+  background: rgba(98, 86, 255, 0.12);
+}
+
+.button--ghost:active {
+  transform: none;
+  box-shadow: none;
+  background: rgba(98, 86, 255, 0.18);
+}
+
+.button--compact {
+  padding: 0.6rem 1.2rem;
+  min-height: 44px;
+  box-shadow: none;
+}
+
+.ideas-toolbar,
+.guest-toolbar,
+.budget-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.ideas-filter,
+.guest-filter,
+.budget-filter {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 180px;
+}
+
+.ideas-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.idea-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 20px;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid rgba(98, 86, 255, 0.12);
+  box-shadow: 0 16px 32px rgba(31, 35, 48, 0.1);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.idea-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.idea-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.idea-card__title:hover {
+  color: var(--brand-dark);
+}
+
+.idea-card__category {
+  background: rgba(98, 86, 255, 0.12);
+  color: var(--brand-dark);
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.idea-card__note {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.idea-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.idea-card__like,
+.idea-card__delete,
+.guest-card__delete,
+.budget-row__delete {
+  border: none;
+  font: inherit;
+  font-weight: 600;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.idea-card__like {
+  background: rgba(98, 86, 255, 0.12);
+  color: var(--brand-dark);
+}
+
+.idea-card__like.is-liked {
+  background: rgba(98, 86, 255, 0.22);
+}
+
+.idea-card__delete,
+.guest-card__delete,
+.budget-row__delete {
+  background: rgba(238, 84, 110, 0.12);
+  color: #d53d57;
+}
+
+.idea-card__like:hover,
+.idea-card__delete:hover,
+.guest-card__delete:hover,
+.budget-row__delete:hover {
+  transform: translateY(-1px);
+}
+
+.idea-card__like:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.idea-card__empty {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 1.4rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(98, 86, 255, 0.12);
+}
+
+.guest-summary,
+.budget-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.guest-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.1rem;
+}
+
+.guest-card {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 22px;
+  padding: 1.1rem 1.2rem;
+  border: 1px solid rgba(98, 86, 255, 0.12);
+  box-shadow: 0 16px 32px rgba(31, 35, 48, 0.1);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.guest-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.guest-card__header-content {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.guest-card__name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.guest-card__meta {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.guest-card__controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.guest-card__field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.guest-card__details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.guest-card__notes {
+  min-height: 80px;
+}
+
+.guest-card--empty {
+  text-align: center;
+  padding: 1.4rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(98, 86, 255, 0.12);
+}
+
+.guest-card__empty-message {
+  margin: 0;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.budget-target {
+  display: grid;
+  gap: 0.35rem;
+  background: rgba(255, 255, 255, 0.85);
+  padding: 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(98, 86, 255, 0.12);
+}
+
+.budget-target__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.budget-target__controls input {
+  flex: 1 1 160px;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(98, 86, 255, 0.12);
+  box-shadow: 0 16px 32px rgba(31, 35, 48, 0.1);
+}
+
+.budget-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+}
+
+.budget-table thead {
+  background: rgba(98, 86, 255, 0.08);
+}
+
+.budget-table th {
+  text-align: left;
+  padding: 0.9rem 1rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.budget-table td {
+  padding: 0.85rem 1rem;
+  border-top: 1px solid rgba(98, 86, 255, 0.12);
+  font-size: 0.95rem;
+}
+
+.budget-table__cell--number {
+  text-align: right;
+}
+
+.budget-table__cell--title {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.budget-table__cell--actions {
+  text-align: right;
+}
+
+.budget-table__cell--paid {
+  text-align: center;
+}
+
+.budget-table__empty td {
+  text-align: center;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.budget-row__actual {
+  max-width: 140px;
+}
+
+.budget-row__paid-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.budget-row__paid {
+  width: 18px;
+  height: 18px;
+}
+
+.budget-diff {
+  font-weight: 600;
+}
+
+.budget-diff--positive {
+  color: var(--priority-low-text);
+}
+
+.budget-diff--negative {
+  color: #d53d57;
+}
+
+.budget-summary__item {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 18px;
+  padding: 1rem;
+  border: 1px solid rgba(98, 86, 255, 0.12);
+  box-shadow: 0 8px 20px rgba(31, 35, 48, 0.08);
+  display: grid;
+  gap: 0.35rem;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- implement realtime guests manager with form, filters, counters and CSV export
- add ideas inspiration board with likes, filtering, and Firebase sync
- build budget tracking section with target, table, inline editing and summaries
- extend Firebase module to expose guests, ideas and budget APIs

## Testing
- node --check app.js

------
https://chatgpt.com/codex/tasks/task_e_68d16b682ce4832d8c883cc783d5573d