### PR TITLE
Add full-screen preview for idea images

### DIFF
--- a/style.css
+++ b/style.css
@@ -932,6 +932,23 @@ body {
   aspect-ratio: 4 / 3;
 }
 
+.idea-card__preview {
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  cursor: zoom-in;
+  display: block;
+}
+
+.idea-card__preview:focus-visible {
+  outline: 3px solid rgba(98, 86, 255, 0.45);
+  outline-offset: 3px;
+  border-radius: 16px;
+}
+
 .idea-card__image {
   display: block;
   width: 100%;
@@ -1027,6 +1044,88 @@ body {
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.9);
   border: 1px solid rgba(98, 86, 255, 0.12);
+}
+
+body.idea-image-viewer-open {
+  overflow: hidden;
+}
+
+.idea-image-viewer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+  z-index: 1200;
+}
+
+.idea-image-viewer.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.idea-image-viewer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(17, 19, 30, 0.7);
+}
+
+.idea-image-viewer__dialog {
+  position: relative;
+  z-index: 1;
+  background: rgba(255, 255, 255, 0.98);
+  border-radius: 20px;
+  padding: 1.25rem 1.35rem 1.5rem;
+  box-shadow: 0 32px 48px rgba(31, 35, 48, 0.25);
+  width: min(720px, 100%);
+  max-height: calc(100vh - 4rem);
+  overflow: auto;
+}
+
+.idea-image-viewer__figure {
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.idea-image-viewer__image {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 14px;
+}
+
+.idea-image-viewer__caption {
+  margin: 0;
+  text-align: center;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.idea-image-viewer__close {
+  position: absolute;
+  top: 0.8rem;
+  right: 0.85rem;
+  border: none;
+  background: rgba(31, 35, 48, 0.08);
+  color: var(--text-primary);
+  font: inherit;
+  font-weight: 600;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.idea-image-viewer__close:hover {
+  background: rgba(31, 35, 48, 0.14);
+  transform: translateY(-1px);
 }
 
 .guest-summary,


### PR DESCRIPTION
## Summary
- make idea images inside cards clickable to open an enlarged preview
- add an accessible modal viewer with keyboard and focus management for idea images
- style the new preview button and modal overlay to match the existing UI

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1780c7c34832d83b3d18806fe0f2f