### PR TITLE
Add wedding timeline with Firebase-backed milestones

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,16 @@
               Checklist
             </button>
             <button
+              id="cronograma-tab"
+              class="tabs__tab"
+              type="button"
+              data-target="cronograma"
+              aria-controls="cronograma"
+              aria-selected="false"
+            >
+              Cronograma
+            </button>
+            <button
               id="ideas-tab"
               class="tabs__tab"
               type="button"
@@ -157,6 +167,83 @@
               </div>
 
               <ul class="checklist__list" id="task-list"></ul>
+            </div>
+          </section>
+
+          <section id="cronograma" class="tab-content" role="tabpanel" aria-labelledby="cronograma-tab">
+            <div class="panel">
+              <header class="panel__header">
+                <h2 class="panel__title">Cronograma</h2>
+                <p class="panel__subtitle">
+                  Define hitos, asigna responsables y controla recordatorios para mantener el ritmo de la organización.
+                </p>
+              </header>
+
+              <form id="milestone-form" class="form-grid timeline-form" autocomplete="off">
+                <div class="form-field form-field--full">
+                  <label class="form-label" for="milestone-title">Hito</label>
+                  <input
+                    id="milestone-title"
+                    class="form-control"
+                    type="text"
+                    placeholder="Reunión con el catering, prueba de vestido…"
+                    required
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="milestone-date">Fecha</label>
+                  <input id="milestone-date" class="form-control" type="date" required />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="milestone-status">Estado</label>
+                  <select id="milestone-status" class="form-control" required>
+                    <option value="planned" selected>Planificado</option>
+                    <option value="in-progress">En curso</option>
+                    <option value="done">Completado</option>
+                  </select>
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="milestone-responsibles">Responsables</label>
+                  <input
+                    id="milestone-responsibles"
+                    class="form-control"
+                    type="text"
+                    placeholder="Nombres separados por coma"
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="milestone-reminder">Recordatorio</label>
+                  <select id="milestone-reminder" class="form-control" required>
+                    <option value="none" selected>Sin recordatorio</option>
+                    <option value="1w">Una semana antes</option>
+                    <option value="3d">Tres días antes</option>
+                    <option value="1d">Un día antes</option>
+                  </select>
+                </div>
+
+                <button class="button form-submit timeline-form__submit" type="submit">Agregar hito</button>
+              </form>
+
+              <div class="timeline-summary" aria-live="polite">
+                <div class="summary__item">
+                  <span class="summary__label">Planificados</span>
+                  <strong id="milestone-planned" class="summary__value">0</strong>
+                </div>
+                <div class="summary__item">
+                  <span class="summary__label">En curso</span>
+                  <strong id="milestone-in-progress" class="summary__value">0</strong>
+                </div>
+                <div class="summary__item">
+                  <span class="summary__label">Completados</span>
+                  <strong id="milestone-done" class="summary__value">0</strong>
+                </div>
+              </div>
+
+              <ol id="timeline-list" class="timeline" aria-live="polite"></ol>
             </div>
           </section>
 

--- a/style.css
+++ b/style.css
@@ -886,6 +886,207 @@ body {
   min-height: 52px;
 }
 
+.timeline-form {
+  margin-top: 1.4rem;
+}
+
+.timeline-form__submit {
+  width: 100%;
+}
+
+.timeline-summary {
+  margin-top: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.timeline {
+  position: relative;
+  margin: 2rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 12px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(98, 86, 255, 0.28), rgba(247, 143, 109, 0.28));
+  pointer-events: none;
+}
+
+.timeline__item {
+  position: relative;
+  padding-left: 52px;
+  --timeline-accent: rgba(98, 86, 255, 0.9);
+  --timeline-surface: rgba(98, 86, 255, 0.16);
+}
+
+.timeline__item[data-status='in-progress'] {
+  --timeline-accent: var(--accent);
+  --timeline-surface: rgba(247, 143, 109, 0.2);
+}
+
+.timeline__item[data-status='done'] {
+  --timeline-accent: var(--priority-low-text);
+  --timeline-surface: rgba(94, 201, 142, 0.22);
+}
+
+.timeline__marker {
+  position: absolute;
+  left: 0;
+  top: 28px;
+  width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+}
+
+.timeline__point {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--timeline-accent);
+  box-shadow: 0 0 0 6px var(--timeline-surface);
+  border: 2px solid #ffffff;
+}
+
+.timeline__card {
+  position: relative;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(98, 86, 255, 0.14);
+  border-left: 4px solid var(--timeline-accent);
+  border-radius: 20px;
+  padding: 1.2rem 1.4rem;
+  box-shadow: 0 18px 36px rgba(31, 35, 48, 0.12);
+  display: grid;
+  gap: 1.1rem;
+}
+
+.timeline__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+}
+
+.timeline__date {
+  font-weight: 600;
+  color: var(--brand-dark);
+  font-size: 0.95rem;
+}
+
+.timeline__status {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-end;
+  min-width: 160px;
+}
+
+.timeline__field-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.timeline__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.timeline__title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.timeline__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.timeline__action {
+  padding: 0.5rem 0.9rem;
+  font-size: 0.85rem;
+}
+
+.timeline__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.timeline__field {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.timeline__empty {
+  list-style: none;
+  margin: 0;
+  padding-left: 52px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+@media (max-width: 720px) {
+  .timeline::before {
+    left: 8px;
+  }
+
+  .timeline__item {
+    padding-left: 40px;
+  }
+
+  .timeline__marker {
+    top: 24px;
+    width: 26px;
+    height: 26px;
+  }
+
+  .timeline__card {
+    padding: 1rem 1.1rem;
+  }
+
+  .timeline__status {
+    align-items: flex-start;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .timeline__actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 480px) {
+  .timeline__meta {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline__action {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
+}
+
 .button--ghost {
   background: transparent;
   color: var(--brand-dark);


### PR DESCRIPTION
## Summary
- add Cronograma tab with milestone form, status counters and timeline container
- implement milestone store with Firebase sync, inline editing and reminder handling
- style responsive timeline components with state-driven markers and cards

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d18be4a0e4832d91ea4c82b8e2a95e