### PR TITLE
Enhance ideas moodboard features

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,7 +269,31 @@
                 </div>
 
                 <div class="form-field">
-                  <label class="form-label" for="idea-url">URL</label>
+                  <label class="form-label" for="idea-category">Categoría</label>
+                  <input
+                    id="idea-category"
+                    class="form-control"
+                    type="text"
+                    placeholder="Decoración, música, viaje…"
+                    required
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="idea-order">Orden manual</label>
+                  <input
+                    id="idea-order"
+                    class="form-control"
+                    type="number"
+                    min="0"
+                    step="1"
+                    inputmode="numeric"
+                    placeholder="1, 2, 3…"
+                  />
+                </div>
+
+                <div class="form-field">
+                  <label class="form-label" for="idea-url">URL principal</label>
                   <input
                     id="idea-url"
                     class="form-control"
@@ -279,24 +303,55 @@
                 </div>
 
                 <div class="form-field form-field--full">
-                  <label class="form-label" for="idea-image">Imagen</label>
+                  <label class="form-label" for="idea-images">Imágenes</label>
                   <input
-                    id="idea-image"
+                    id="idea-images"
                     class="form-control form-control--file"
                     type="file"
                     accept="image/*"
+                    multiple
                   />
+                  <p class="form-hint">Selecciona varias imágenes para crear un mosaico.</p>
                 </div>
 
-                <div class="form-field">
-                  <label class="form-label" for="idea-category">Categoría</label>
-                  <input
-                    id="idea-category"
-                    class="form-control"
-                    type="text"
-                    placeholder="Decoración, música, viaje…"
-                    required
-                  />
+                <div class="form-field form-field--full form-field--palette">
+                  <span class="form-label">Paleta de color</span>
+                  <div class="palette-inputs">
+                    <label class="palette-inputs__item" for="idea-color-primary">
+                      <span>Primario</span>
+                      <input id="idea-color-primary" class="palette-inputs__control" type="color" value="#6256ff" />
+                    </label>
+                    <label class="palette-inputs__item" for="idea-color-secondary">
+                      <span>Secundario</span>
+                      <input id="idea-color-secondary" class="palette-inputs__control" type="color" value="#f8dada" />
+                    </label>
+                    <label class="palette-inputs__item" for="idea-color-accent">
+                      <span>Acento</span>
+                      <input id="idea-color-accent" class="palette-inputs__control" type="color" value="#ffeab5" />
+                    </label>
+                  </div>
+                </div>
+
+                <div class="form-field form-field--full">
+                  <label class="form-label" for="idea-checklist-links">Checklist relacionada</label>
+                  <textarea
+                    id="idea-checklist-links"
+                    class="form-control form-control--textarea"
+                    rows="2"
+                    placeholder="Título de la tarea | https://enlace"
+                  ></textarea>
+                  <p class="form-hint">Escribe un vínculo por línea. Usa “Título | URL” para enlazar directamente.</p>
+                </div>
+
+                <div class="form-field form-field--full">
+                  <label class="form-label" for="idea-vendor-links">Proveedores relacionados</label>
+                  <textarea
+                    id="idea-vendor-links"
+                    class="form-control form-control--textarea"
+                    rows="2"
+                    placeholder="Nombre del proveedor | https://sitio"
+                  ></textarea>
+                  <p class="form-hint">Añade accesos rápidos a fichas de proveedores o presupuestos.</p>
                 </div>
 
                 <div class="form-field form-field--full">

--- a/style.css
+++ b/style.css
@@ -805,8 +805,61 @@ body {
   gap: 0.35rem;
 }
 
+.form-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
 .form-field--full {
   grid-column: 1 / -1;
+}
+
+.form-field--palette {
+  border: 1px dashed rgba(98, 86, 255, 0.2);
+  border-radius: 14px;
+  padding: 0.75rem;
+  background: rgba(98, 86, 255, 0.08);
+}
+
+.palette-inputs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.palette-inputs__item {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.palette-inputs__control {
+  width: 64px;
+  height: 36px;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: #ffffff;
+  padding: 0;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.9);
+}
+
+.palette-inputs__control::-webkit-color-swatch,
+.palette-inputs__control::-webkit-color-swatch-wrapper {
+  border: none;
+  border-radius: 10px;
+  padding: 0;
+}
+
+.palette-inputs__control::-moz-color-swatch {
+  border: none;
+  border-radius: 10px;
 }
 
 .form-label,
@@ -1131,39 +1184,135 @@ body {
 
 .ideas-grid {
   display: grid;
-  gap: 1.2rem;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
 }
 
 .idea-card {
-  background: rgba(255, 255, 255, 0.92);
-  border-radius: 20px;
-  padding: 1.1rem 1.2rem;
-  border: 1px solid rgba(98, 86, 255, 0.12);
-  box-shadow: 0 16px 32px rgba(31, 35, 48, 0.1);
+  position: relative;
   display: grid;
-  gap: 0.75rem;
+  gap: 1rem;
+  padding: 1.2rem;
+  border-radius: 22px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(245, 241, 255, 0.92));
+  border: 1px solid rgba(98, 86, 255, 0.16);
+  box-shadow: 0 18px 36px rgba(24, 20, 63, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.idea-card__media {
+.idea-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 42px rgba(24, 20, 63, 0.16);
+}
+
+.idea-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.idea-card__header-main {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.idea-card__title {
   margin: 0;
-  border-radius: 16px;
-  overflow: hidden;
-  background: rgba(98, 86, 255, 0.08);
-  aspect-ratio: 4 / 3;
+  font-size: 1.15rem;
+  line-height: 1.2;
+  font-weight: 700;
+  color: var(--text-primary);
+  text-decoration: none;
 }
 
+.idea-card__title:hover {
+  color: var(--brand-dark);
+}
+
+.idea-card__category {
+  align-self: flex-start;
+  background: rgba(98, 86, 255, 0.16);
+  color: var(--brand-dark);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.idea-card__order {
+  align-self: flex-start;
+  background: rgba(247, 143, 109, 0.16);
+  color: #c2623d;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.idea-card__gallery {
+  display: grid;
+  gap: 0.55rem;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-auto-rows: 60px;
+  border-radius: 18px;
+  background: rgba(98, 86, 255, 0.08);
+  padding: 0.6rem;
+  overflow: hidden;
+}
+
+.idea-card__thumb,
 .idea-card__preview {
   border: none;
   background: transparent;
   padding: 0;
   margin: 0;
+  display: block;
   width: 100%;
   height: 100%;
+  border-radius: 14px;
+  overflow: hidden;
   cursor: zoom-in;
-  display: block;
+  position: relative;
+  box-shadow: 0 10px 20px rgba(31, 35, 48, 0.12);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
+.idea-card__thumb {
+  grid-column: span 2;
+  grid-row: span 2;
+  min-height: 90px;
+}
+
+.idea-card__thumb--main {
+  grid-column: span 6;
+  grid-row: span 4;
+  min-height: 220px;
+  box-shadow: 0 14px 26px rgba(31, 35, 48, 0.18);
+}
+
+.idea-card__thumb--wide {
+  grid-column: span 3;
+  grid-row: span 2;
+}
+
+.idea-card__thumb--tall {
+  grid-column: span 2;
+  grid-row: span 3;
+}
+
+.idea-card__thumb:hover,
+.idea-card__preview:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 26px rgba(31, 35, 48, 0.2);
+}
+
+.idea-card__thumb:focus-visible,
 .idea-card__preview:focus-visible {
   outline: 3px solid rgba(98, 86, 255, 0.45);
   outline-offset: 3px;
@@ -1177,44 +1326,125 @@ body {
   object-fit: cover;
 }
 
-.idea-card__header {
+.idea-card__palette {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 0.75rem;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 15px;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(98, 86, 255, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
 }
 
-.idea-card__title {
-  margin: 0;
-  font-size: 1.05rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  text-decoration: none;
-}
-
-.idea-card__title:hover {
-  color: var(--brand-dark);
-}
-
-.idea-card__category {
-  background: rgba(98, 86, 255, 0.12);
-  color: var(--brand-dark);
-  padding: 0.25rem 0.65rem;
-  border-radius: 999px;
+.idea-card__palette-title {
   font-size: 0.75rem;
-  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+  color: var(--text-muted);
+}
+
+.idea-card__palette-swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.idea-card__swatch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(98, 86, 255, 0.18);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--text-primary);
+  text-transform: uppercase;
+}
+
+.idea-card__swatch::before {
+  content: '';
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--swatch-color);
+  box-shadow: 0 2px 6px rgba(17, 17, 38, 0.22);
+  border: 2px solid rgba(255, 255, 255, 0.85);
 }
 
 .idea-card__note {
   margin: 0;
+  color: var(--text-primary);
+  background: rgba(255, 255, 255, 0.82);
+  border-radius: 16px;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid rgba(98, 86, 255, 0.12);
+  line-height: 1.45;
+}
+
+.idea-card__relations {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.idea-card__relation-group {
+  display: grid;
+  gap: 0.4rem;
+  padding: 0.6rem 0.85rem;
+  border-radius: 16px;
+  background: rgba(98, 86, 255, 0.08);
+  border: 1px solid rgba(98, 86, 255, 0.18);
+}
+
+.idea-card__relation-group--vendors {
+  background: rgba(255, 189, 139, 0.12);
+  border-color: rgba(255, 189, 139, 0.32);
+}
+
+.idea-card__relation-title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
   color: var(--text-muted);
+}
+
+.idea-card__relation-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.idea-card__relation-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(98, 86, 255, 0.18);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.idea-card__relation-chip:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(31, 35, 48, 0.14);
 }
 
 .idea-card__footer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  padding-top: 0.25rem;
 }
 
 .idea-card__like,
@@ -1224,26 +1454,31 @@ body {
   border: none;
   font: inherit;
   font-weight: 600;
-  padding: 0.45rem 0.85rem;
+  padding: 0.45rem 0.95rem;
   border-radius: 999px;
   cursor: pointer;
-  transition: background-color 0.2s ease, transform 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
 }
 
 .idea-card__like {
-  background: rgba(98, 86, 255, 0.12);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: rgba(98, 86, 255, 0.18);
   color: var(--brand-dark);
+  box-shadow: 0 4px 10px rgba(98, 86, 255, 0.18);
 }
 
 .idea-card__like.is-liked {
-  background: rgba(98, 86, 255, 0.22);
+  background: rgba(98, 86, 255, 0.26);
 }
 
 .idea-card__delete,
 .guest-card__delete,
 .budget-row__delete {
-  background: rgba(238, 84, 110, 0.12);
+  background: rgba(238, 84, 110, 0.14);
   color: #d53d57;
+  box-shadow: 0 4px 10px rgba(238, 84, 110, 0.16);
 }
 
 .idea-card__like:hover,
@@ -1251,20 +1486,22 @@ body {
 .guest-card__delete:hover,
 .budget-row__delete:hover {
   transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(31, 35, 48, 0.18);
 }
 
 .idea-card__like:disabled {
   opacity: 0.65;
   cursor: not-allowed;
+  box-shadow: none;
 }
 
 .idea-card__empty {
   text-align: center;
   color: var(--text-muted);
-  padding: 1.4rem;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(98, 86, 255, 0.12);
+  padding: 1.6rem;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px dashed rgba(98, 86, 255, 0.18);
 }
 
 .venues-summary {


### PR DESCRIPTION
## Summary
- allow capturing richer inspiration metadata with multi-image uploads, color palette pickers, manual ordering and related quick links in the Ideas form
- extend the ideas store and rendering logic to persist and display image galleries, palettes, relations and manual ordering while preserving shared like counts
- refresh moodboard styling for ideas cards with gallery mosaics, color chips and relation tags, plus supportive form hints and palette controls

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2c2f11c54832dba1acee15bbc60a4