### PR TITLE
Improve venue comparison table responsiveness

### DIFF
--- a/app.js
+++ b/app.js
@@ -5063,7 +5063,8 @@ const createVenueTableRow = (venue) => {
   row.dataset.id = venue.id;
 
   const nameCell = document.createElement('td');
-  nameCell.className = 'venue-table__name';
+  nameCell.className = 'venue-table__cell venue-table__cell--name';
+  nameCell.dataset.label = 'Nombre';
   nameCell.textContent = venue.name;
   if (venue.address) {
     const address = document.createElement('div');
@@ -5074,6 +5075,8 @@ const createVenueTableRow = (venue) => {
   row.append(nameCell);
 
   const capacityCell = document.createElement('td');
+  capacityCell.className = 'venue-table__cell venue-table__cell--metric';
+  capacityCell.dataset.label = 'Capacidad';
   const capacityInput = document.createElement('input');
   capacityInput.type = 'number';
   capacityInput.min = '0';
@@ -5090,6 +5093,8 @@ const createVenueTableRow = (venue) => {
   row.append(capacityCell);
 
   const priceCell = document.createElement('td');
+  priceCell.className = 'venue-table__cell venue-table__cell--metric';
+  priceCell.dataset.label = 'Precio';
   const priceInput = document.createElement('input');
   priceInput.type = 'number';
   priceInput.min = '0';
@@ -5106,6 +5111,8 @@ const createVenueTableRow = (venue) => {
   row.append(priceCell);
 
   const statusCell = document.createElement('td');
+  statusCell.className = 'venue-table__cell venue-table__cell--status';
+  statusCell.dataset.label = 'Estado';
   const statusSelect = document.createElement('select');
   statusSelect.className = 'venue-table__status';
   statusSelect.dataset.action = 'status-select';
@@ -5121,6 +5128,8 @@ const createVenueTableRow = (venue) => {
   row.append(statusCell);
 
   const dateCell = document.createElement('td');
+  dateCell.className = 'venue-table__cell venue-table__cell--date';
+  dateCell.dataset.label = 'Fecha';
   const dateInput = document.createElement('input');
   dateInput.type = 'date';
   dateInput.className = 'venue-table__quick-input';
@@ -5133,22 +5142,28 @@ const createVenueTableRow = (venue) => {
   const shouldShowLegacyNotes = !venue.pros && !venue.cons && venue.notes;
 
   const prosCell = document.createElement('td');
-  prosCell.className = 'venue-table__pros';
+  prosCell.className = 'venue-table__cell venue-table__cell--text venue-table__pros';
+  prosCell.dataset.label = 'Pros';
   prosCell.textContent =
     venue.pros || (shouldShowLegacyNotes ? venue.notes : '') || '—';
   row.append(prosCell);
 
   const consCell = document.createElement('td');
-  consCell.className = 'venue-table__cons';
+  consCell.className = 'venue-table__cell venue-table__cell--text venue-table__cons';
+  consCell.dataset.label = 'Contras';
   consCell.textContent = venue.cons || '—';
   row.append(consCell);
 
   const contactCell = document.createElement('td');
+  contactCell.className = 'venue-table__cell venue-table__cell--text';
+  contactCell.dataset.label = 'Contacto';
   contactCell.textContent = venue.contact || '—';
   row.append(contactCell);
 
   const actionsCell = document.createElement('td');
-  actionsCell.className = 'venue-table__actions';
+  actionsCell.className =
+    'venue-table__cell venue-table__cell--actions venue-table__actions';
+  actionsCell.dataset.label = 'Acciones';
 
   const favoriteButton = createVenueTableButton('Favorito', 'toggle-favorite', {
     isActive: venue.status === 'favorito',
@@ -5222,6 +5237,8 @@ const renderVenueTable = (items) => {
     const emptyRow = document.createElement('tr');
     emptyRow.className = 'venue-table__empty';
     const cell = document.createElement('td');
+    cell.className = 'venue-table__cell venue-table__cell--empty';
+    cell.dataset.label = '';
     cell.colSpan = 9;
     cell.textContent = venuesData.length
       ? 'No hay lugares que coincidan con los filtros.'

--- a/style.css
+++ b/style.css
@@ -740,7 +740,8 @@ body {
   }
 
   .venues-table__inner {
-    min-width: 560px;
+    min-width: 0;
+    width: 100%;
   }
 }
 
@@ -1854,6 +1855,8 @@ body {
   border-radius: 20px;
   box-shadow: 0 18px 34px rgba(31, 35, 48, 0.08);
   overflow: hidden;
+  table-layout: fixed;
+  border: 1px solid rgba(98, 86, 255, 0.12);
 }
 
 .venues-table__inner thead {
@@ -1868,6 +1871,9 @@ body {
   text-transform: uppercase;
   font-weight: 700;
   color: var(--text-muted);
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 .venues-table__inner td {
@@ -1877,19 +1883,50 @@ body {
   vertical-align: top;
 }
 
-.venue-table__name {
+.venues-table__inner tbody tr {
+  transition: background-color 0.18s ease, transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.venues-table__inner tbody tr:nth-child(even) {
+  background: rgba(98, 86, 255, 0.04);
+}
+
+.venues-table__inner tbody tr:hover {
+  background: rgba(98, 86, 255, 0.12);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(31, 35, 48, 0.08);
+}
+
+.venue-table__cell {
+  position: relative;
+}
+
+.venue-table__cell--name {
   font-weight: 600;
   color: var(--text-primary);
+  font-size: 1.05rem;
+}
+
+.venue-table__cell--metric {
+  text-align: center;
 }
 
 .venue-table__quick-input {
   width: 100%;
-  max-width: 120px;
+  max-width: 140px;
   padding: 0.45rem 0.6rem;
   border-radius: 10px;
   border: 1px solid rgba(98, 86, 255, 0.2);
   font: inherit;
   background: #ffffff;
+}
+
+.venue-table__cell--metric .venue-table__quick-input {
+  font-weight: 600;
+  background: rgba(98, 86, 255, 0.08);
+  border-color: rgba(98, 86, 255, 0.24);
+  color: var(--brand-dark);
+  text-align: center;
 }
 
 .venue-table__quick-input:focus-visible {
@@ -1903,6 +1940,22 @@ body {
   padding: 0.5rem 0.6rem;
   font: inherit;
   background: #ffffff;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%236256ff' d='M1.41 0L6 4.58 10.59 0 12 1.41 6 7.41 0 1.41z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 0.7rem;
+  padding-right: 2.2rem;
+}
+
+.venue-table__cell--status .venue-table__status {
+  width: 100%;
+  min-width: 0;
+  font-weight: 600;
+  background: rgba(98, 86, 255, 0.08);
+  border-color: rgba(98, 86, 255, 0.24);
+  color: var(--brand-dark);
 }
 
 .venue-table__actions {
@@ -1913,6 +1966,9 @@ body {
 }
 
 .venue-table__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border-radius: 10px;
   border: 1px solid rgba(98, 86, 255, 0.24);
   background: rgba(98, 86, 255, 0.1);
@@ -1921,6 +1977,8 @@ body {
   color: var(--brand-dark);
   cursor: pointer;
   transition: background-color 0.2s ease, color 0.2s ease;
+  text-decoration: none;
+  white-space: nowrap;
 }
 
 .venue-table__button:hover {
@@ -1935,6 +1993,139 @@ body {
 
 .venue-table__button--danger:hover {
   background: rgba(238, 84, 110, 0.18);
+}
+
+.venue-table__cell--text {
+  color: var(--text-muted);
+  word-break: break-word;
+}
+
+.venue-table__cell--actions {
+  padding-right: 1.2rem;
+}
+
+.venue-table__cell--actions .venue-table__actions {
+  justify-content: flex-end;
+}
+
+@media (max-width: 900px) {
+  .venues-table__inner {
+    box-shadow: 0 14px 26px rgba(31, 35, 48, 0.08);
+  }
+
+  .venue-table__cell--actions {
+    padding-right: 1rem;
+  }
+
+  .venue-table__cell--actions .venue-table__actions {
+    justify-content: flex-start;
+  }
+
+  .venue-table__quick-input {
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  .venues-table {
+    overflow: visible;
+  }
+
+  .venues-table__inner {
+    background: transparent;
+    border-radius: 0;
+    border: none;
+    box-shadow: none;
+  }
+
+  .venues-table__inner,
+  .venues-table__inner tbody,
+  .venues-table__inner tr,
+  .venues-table__inner td {
+    display: block;
+    width: 100%;
+  }
+
+  .venues-table__inner thead {
+    display: none;
+  }
+
+  .venues-table__inner tbody tr {
+    background: rgba(255, 255, 255, 0.98);
+    border: 1px solid rgba(98, 86, 255, 0.18);
+    border-radius: 18px;
+    box-shadow: 0 16px 30px rgba(31, 35, 48, 0.16);
+    margin-bottom: 1.1rem;
+    padding: 0.4rem 0;
+    transform: none !important;
+    transition: none;
+  }
+
+  .venues-table__inner tbody tr:hover {
+    background: rgba(255, 255, 255, 0.98);
+    box-shadow: 0 16px 30px rgba(31, 35, 48, 0.16);
+  }
+
+  .venue-table__cell {
+    display: grid;
+    gap: 0.35rem;
+    border-top: 1px solid rgba(98, 86, 255, 0.12);
+    padding: 0.75rem 1rem;
+  }
+
+  .venue-table__cell:first-of-type {
+    border-top: none;
+  }
+
+  .venue-table__cell::before {
+    content: attr(data-label);
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    font-weight: 600;
+  }
+
+  .venue-table__cell:not([data-label])::before,
+  .venue-table__cell[data-label='']::before {
+    content: none;
+  }
+
+  .venue-table__cell--name {
+    padding-top: 1rem;
+    padding-bottom: 0.5rem;
+  }
+
+  .venue-table__cell--name::before {
+    display: none;
+  }
+
+  .venue-table__cell--metric {
+    text-align: left;
+  }
+
+  .venue-table__cell--metric .venue-table__quick-input {
+    text-align: left;
+  }
+
+  .venue-table__cell--actions {
+    padding-bottom: 1rem;
+  }
+
+  .venue-table__cell--actions .venue-table__actions {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.55rem;
+  }
+
+  .venue-table__button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .venue-table__cell--empty {
+    padding: 1.5rem 1rem;
+  }
 }
 
 .venue-table__empty {


### PR DESCRIPTION
## Summary
- enhance the venue table markup with contextual data labels to support the responsive layout
- refresh the table styling with sticky headers, zebra rows, and clearer metric treatments for desktop comparison
- transform the table into labeled cards on narrow screens so each venue is easier to read and manage on mobile

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68daaff8b9f8832dada2e44918428836