### PR TITLE
Actualizar columna final del presupuesto

### DIFF
--- a/app.js
+++ b/app.js
@@ -6154,6 +6154,73 @@ const applyBudgetUsageStyles = (cell, item) => {
   cell.classList.toggle('budget-usage--under', withinBudget);
 };
 
+const renderBudgetUsageCellContent = (cell, item) => {
+  if (!cell) {
+    return;
+  }
+
+  cell.textContent = '';
+
+  const hasActual = Number.isFinite(item.act);
+  const hasEstimate = Number.isFinite(item.est);
+
+  if (!hasActual && !hasEstimate) {
+    cell.textContent = '—';
+    return;
+  }
+
+  const content = document.createElement('div');
+  content.className = 'budget-usage__content';
+
+  if (hasActual) {
+    const actualLine = document.createElement('div');
+    actualLine.className = 'budget-usage__line budget-usage__line--actual';
+
+    const actualAmount = document.createElement('strong');
+    actualAmount.className = 'budget-usage__amount budget-usage__amount--actual';
+    actualAmount.textContent = formatMoney(item.act);
+
+    const actualBadge = document.createElement('span');
+    actualBadge.className = 'budget-usage__badge budget-usage__badge--actual';
+    actualBadge.textContent = 'Real';
+
+    actualLine.append(actualAmount, actualBadge);
+    content.append(actualLine);
+
+    if (hasEstimate) {
+      const estimateLine = document.createElement('div');
+      estimateLine.className = 'budget-usage__line budget-usage__line--estimate';
+
+      const estimateAmount = document.createElement('span');
+      estimateAmount.className = 'budget-usage__amount budget-usage__amount--estimate';
+      estimateAmount.textContent = formatMoney(item.est);
+
+      const estimateBadge = document.createElement('span');
+      estimateBadge.className = 'budget-usage__badge budget-usage__badge--estimate';
+      estimateBadge.textContent = 'Est.';
+
+      estimateLine.append(estimateAmount, estimateBadge);
+      content.append(estimateLine);
+    }
+  } else if (hasEstimate) {
+    const estimateLine = document.createElement('div');
+    estimateLine.className = 'budget-usage__line budget-usage__line--estimate-only';
+
+    const estimateAmount = document.createElement('span');
+    estimateAmount.className = 'budget-usage__amount budget-usage__amount--estimate-only';
+    estimateAmount.textContent = formatMoney(item.est);
+
+    const estimateBadge = document.createElement('span');
+    estimateBadge.className = 'budget-usage__badge budget-usage__badge--estimate';
+    estimateBadge.textContent = 'Est.';
+
+    estimateLine.append(estimateAmount, estimateBadge);
+    content.append(estimateLine);
+  }
+
+  cell.append(content);
+};
+
 const patchBudgetStateItem = (itemId, changes) => {
   let updatedItem = null;
 
@@ -6201,8 +6268,7 @@ const createBudgetRow = (item) => {
 
   const usageCell = document.createElement('td');
   usageCell.className = 'budget-table__cell budget-table__cell--number budget-usage';
-  const usageValue = effectiveAmount(item);
-  usageCell.textContent = usageValue === null ? '—' : formatMoney(usageValue);
+  renderBudgetUsageCellContent(usageCell, item);
   applyBudgetUsageStyles(usageCell, item);
 
   const paidCell = document.createElement('td');
@@ -6365,8 +6431,7 @@ const handleBudgetTableChange = (event) => {
       const usageCell = row.querySelector('.budget-usage');
 
       if (usageCell) {
-        const usageValue = effectiveAmount(updatedItem);
-        usageCell.textContent = usageValue === null ? '—' : formatMoney(usageValue);
+        renderBudgetUsageCellContent(usageCell, updatedItem);
         applyBudgetUsageStyles(usageCell, updatedItem);
       }
 

--- a/index.html
+++ b/index.html
@@ -949,7 +949,7 @@
                       <th scope="col">Categoría</th>
                       <th scope="col">Estimado</th>
                       <th scope="col">Real</th>
-                      <th scope="col">Usado</th>
+                      <th scope="col">Final</th>
                       <th scope="col">Pagado</th>
                       <th scope="col">Fecha</th>
                       <th scope="col" class="visually-hidden">Acciones</th>

--- a/style.css
+++ b/style.css
@@ -2438,14 +2438,68 @@ body.idea-image-viewer-open {
 }
 
 .budget-usage {
-  font-weight: 600;
+  font-weight: 400;
 }
 
-.budget-usage--under {
+.budget-usage__content {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.2rem;
+}
+
+.budget-usage__line {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.budget-usage__amount--actual {
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.budget-usage__amount--estimate {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-decoration: line-through;
+}
+
+.budget-usage__amount--estimate-only {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.budget-usage__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.1rem 0.45rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  background: rgba(31, 35, 48, 0.08);
+  color: var(--text-primary);
+}
+
+.budget-usage__badge--actual {
+  background: rgba(94, 201, 142, 0.2);
   color: var(--priority-low-text);
 }
 
-.budget-usage--over {
+.budget-usage__badge--estimate {
+  background: rgba(98, 86, 255, 0.12);
+  color: var(--brand-dark);
+}
+
+.budget-usage--under .budget-usage__amount--actual {
+  color: var(--priority-low-text);
+}
+
+.budget-usage--over .budget-usage__amount--actual {
   color: var(--priority-high-text);
 }
 


### PR DESCRIPTION
## Summary
- renombrar la columna de uso del presupuesto a "Final" y mostrar el importe real o estimado con la moneda formateada
- añadir un renderizado dinámico de la celda que combina badges para distinguir valores reales y estimados y se actualiza tras cada edición
- incorporar los estilos necesarios para los nuevos badges y tipografías de la columna final

## Testing
- No se ejecutaron pruebas (no disponibles)


------
https://chatgpt.com/codex/tasks/task_e_68dbf9211638832da3cc3a0eb89a5dba