### PR TITLE
Amplía el campo de gasto real en la tabla de presupuesto

### DIFF
--- a/style.css
+++ b/style.css
@@ -2421,7 +2421,13 @@ body.idea-image-viewer-open {
 }
 
 .budget-row__actual {
-  max-width: 140px;
+  min-width: 120px;
+}
+
+@media (max-width: 720px) {
+  .budget-row__actual {
+    min-width: 100%;
+  }
 }
 
 .budget-row__paid-label {


### PR DESCRIPTION
## Summary
- increase the minimum width of the "Real" input in budget rows for desktop while keeping full-width behavior on mobile

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbfdd2b014832d8004e9e81d873ab9