### PR TITLE
Adjust budget actual input width on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -2424,9 +2424,11 @@ body.idea-image-viewer-open {
   min-width: 120px;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 768px) {
   .budget-row__actual {
-    min-width: 100%;
+    width: 100%;
+    min-width: 140px;
+    padding: 0.75rem 1rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- widen the Presupuesto "Real" input on small screens to span the table cell comfortably
- ensure the mobile input keeps generous padding while retaining existing desktop sizing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd250822e8832db4ed58a15da770e0