### PR TITLE
Refactor ideas section into Pinterest-style cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,49 +256,15 @@
                 </p>
               </header>
 
-              <form id="idea-form" class="form-grid" autocomplete="off">
+              <form id="idea-form" class="form-grid ideas-form" autocomplete="off">
                 <div class="form-field form-field--full">
-                  <label class="form-label" for="idea-title">Título</label>
+                  <label class="form-label" for="idea-title">Título o descripción</label>
                   <input
                     id="idea-title"
                     class="form-control"
                     type="text"
                     placeholder="Centro de mesa, invitaciones…"
                     required
-                  />
-                </div>
-
-                <div class="form-field">
-                  <label class="form-label" for="idea-category">Categoría</label>
-                  <input
-                    id="idea-category"
-                    class="form-control"
-                    type="text"
-                    placeholder="Decoración, música, viaje…"
-                    required
-                  />
-                </div>
-
-                <div class="form-field">
-                  <label class="form-label" for="idea-order">Orden manual</label>
-                  <input
-                    id="idea-order"
-                    class="form-control"
-                    type="number"
-                    min="0"
-                    step="1"
-                    inputmode="numeric"
-                    placeholder="1, 2, 3…"
-                  />
-                </div>
-
-                <div class="form-field">
-                  <label class="form-label" for="idea-url">URL principal</label>
-                  <input
-                    id="idea-url"
-                    class="form-control"
-                    type="url"
-                    placeholder="https://"
                   />
                 </div>
 
@@ -311,56 +277,26 @@
                     accept="image/*"
                     multiple
                   />
-                  <p class="form-hint">Selecciona varias imágenes para crear un mosaico.</p>
-                </div>
-
-                <div class="form-field form-field--full form-field--palette">
-                  <span class="form-label">Paleta de color</span>
-                  <div class="palette-inputs">
-                    <label class="palette-inputs__item" for="idea-color-primary">
-                      <span>Primario</span>
-                      <input id="idea-color-primary" class="palette-inputs__control" type="color" value="#6256ff" />
-                    </label>
-                    <label class="palette-inputs__item" for="idea-color-secondary">
-                      <span>Secundario</span>
-                      <input id="idea-color-secondary" class="palette-inputs__control" type="color" value="#f8dada" />
-                    </label>
-                    <label class="palette-inputs__item" for="idea-color-accent">
-                      <span>Acento</span>
-                      <input id="idea-color-accent" class="palette-inputs__control" type="color" value="#ffeab5" />
-                    </label>
-                  </div>
+                  <p class="form-hint">Sube imágenes desde tu dispositivo para crear tu tablero visual.</p>
                 </div>
 
                 <div class="form-field form-field--full">
-                  <label class="form-label" for="idea-checklist-links">Checklist relacionada</label>
-                  <textarea
-                    id="idea-checklist-links"
-                    class="form-control form-control--textarea"
-                    rows="2"
-                    placeholder="Título de la tarea | https://enlace"
-                  ></textarea>
-                  <p class="form-hint">Escribe un vínculo por línea. Usa “Título | URL” para enlazar directamente.</p>
+                  <label class="form-label" for="idea-url">Enlace (opcional)</label>
+                  <input
+                    id="idea-url"
+                    class="form-control"
+                    type="url"
+                    placeholder="https://"
+                  />
                 </div>
 
                 <div class="form-field form-field--full">
-                  <label class="form-label" for="idea-vendor-links">Proveedores relacionados</label>
-                  <textarea
-                    id="idea-vendor-links"
-                    class="form-control form-control--textarea"
-                    rows="2"
-                    placeholder="Nombre del proveedor | https://sitio"
-                  ></textarea>
-                  <p class="form-hint">Añade accesos rápidos a fichas de proveedores o presupuestos.</p>
-                </div>
-
-                <div class="form-field form-field--full">
-                  <label class="form-label" for="idea-note">Nota</label>
+                  <label class="form-label" for="idea-note">Nota personal</label>
                   <textarea
                     id="idea-note"
                     class="form-control form-control--textarea"
                     rows="2"
-                    placeholder="Detalles para recordar"
+                    placeholder="Detalles para recordar, materiales, combinaciones…"
                   ></textarea>
                 </div>
 
@@ -374,15 +310,8 @@
                     id="idea-search"
                     class="form-control"
                     type="search"
-                    placeholder="Buscar por título"
+                    placeholder="Buscar por título o nota"
                   />
-                </div>
-
-                <div class="ideas-filter">
-                  <label class="form-label" for="idea-category-filter">Categoría</label>
-                  <select id="idea-category-filter" class="form-control">
-                    <option value="">Todas</option>
-                  </select>
                 </div>
               </div>
 

--- a/style.css
+++ b/style.css
@@ -743,7 +743,6 @@ h6,
     align-items: stretch;
   }
 
-  .ideas-grid,
   .venues-grid,
   .budget-grid {
     grid-template-columns: 1fr;
@@ -857,53 +856,6 @@ h6,
 
 .form-field--full {
   grid-column: 1 / -1;
-}
-
-.form-field--palette {
-  border: 1px dashed rgba(111, 91, 139, 0.2);
-  border-radius: 14px;
-  padding: 0.75rem;
-  background: rgba(111, 91, 139, 0.08);
-}
-
-.palette-inputs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.85rem;
-  align-items: center;
-}
-
-.palette-inputs__item {
-  display: grid;
-  gap: 0.35rem;
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-muted);
-}
-
-.palette-inputs__control {
-  width: 64px;
-  height: 36px;
-  border-radius: 14px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  background: #ffffff;
-  padding: 0;
-  cursor: pointer;
-  box-shadow: inset 0 0 0 2px rgba(253, 250, 246, 0.9);
-}
-
-.palette-inputs__control::-webkit-color-swatch,
-.palette-inputs__control::-webkit-color-swatch-wrapper {
-  border: none;
-  border-radius: 10px;
-  padding: 0;
-}
-
-.palette-inputs__control::-moz-color-swatch {
-  border: none;
-  border-radius: 10px;
 }
 
 .form-label,
@@ -1229,22 +1181,25 @@ h6,
 }
 
 .ideas-grid {
-  display: grid;
-  gap: 1.6rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  align-items: stretch;
+  display: block;
+  width: 100%;
+  column-width: 280px;
+  column-gap: 1.6rem;
 }
 
 .idea-card {
   position: relative;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 1rem;
-  padding: 1.2rem;
+  padding: 1.35rem;
+  margin-bottom: 1.6rem;
   border-radius: 22px;
   background: linear-gradient(145deg, rgba(253, 250, 246, 0.96), rgba(240, 235, 246, 0.92));
   border: 1px solid rgba(111, 91, 139, 0.16);
   box-shadow: 0 18px 34px rgba(45, 35, 56, 0.12);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+  break-inside: avoid;
 }
 
 .idea-card:hover {
@@ -1252,117 +1207,46 @@ h6,
   box-shadow: 0 22px 40px rgba(45, 35, 56, 0.16);
 }
 
-.idea-card__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-}
-
-.idea-card__header-main {
+.idea-card__media {
   display: grid;
-  gap: 0.4rem;
+  gap: 0.75rem;
 }
 
-.idea-card__title {
-  margin: 0;
-  font-size: 1.15rem;
-  line-height: 1.2;
-  font-weight: 700;
-  color: var(--text-primary);
-  text-decoration: none;
+.idea-card__media--multi {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.idea-card__title:hover {
-  color: var(--brand-dark);
-}
-
-.idea-card__category {
-  align-self: flex-start;
-  background: rgba(111, 91, 139, 0.16);
-  color: var(--brand-dark);
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-}
-
-.idea-card__order {
-  align-self: flex-start;
-  background: rgba(200, 160, 96, 0.16);
-  color: #a17a3f;
-  padding: 0.35rem 0.7rem;
-  border-radius: 999px;
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.idea-card__gallery {
-  display: grid;
-  gap: 0.55rem;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
-  grid-auto-rows: 60px;
-  border-radius: 18px;
-  background: rgba(111, 91, 139, 0.08);
-  padding: 0.6rem;
-  overflow: hidden;
-}
-
-.idea-card__thumb,
-.idea-card__preview {
+.idea-card__thumb {
   border: none;
   background: transparent;
   padding: 0;
   margin: 0;
-  display: block;
   width: 100%;
-  height: 100%;
-  border-radius: 14px;
+  border-radius: 18px;
   overflow: hidden;
   cursor: zoom-in;
   position: relative;
-  box-shadow: 0 10px 20px rgba(45, 35, 56, 0.12);
+  box-shadow: 0 12px 28px rgba(45, 35, 56, 0.18);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.idea-card__thumb {
-  grid-column: span 2;
-  grid-row: span 2;
-  min-height: 90px;
-}
-
-.idea-card__thumb--main {
-  grid-column: span 6;
-  grid-row: span 4;
+.idea-card__thumb--primary {
+  grid-column: 1 / -1;
   min-height: 220px;
-  box-shadow: 0 14px 26px rgba(45, 35, 56, 0.18);
 }
 
-.idea-card__thumb--wide {
-  grid-column: span 3;
-  grid-row: span 2;
+.idea-card__thumb--secondary {
+  min-height: 120px;
 }
 
-.idea-card__thumb--tall {
-  grid-column: span 2;
-  grid-row: span 3;
-}
-
-.idea-card__thumb:hover,
-.idea-card__preview:hover {
+.idea-card__thumb:hover {
   transform: translateY(-2px);
-  box-shadow: 0 14px 26px rgba(45, 35, 56, 0.2);
+  box-shadow: 0 16px 30px rgba(45, 35, 56, 0.22);
 }
 
-.idea-card__thumb:focus-visible,
-.idea-card__preview:focus-visible {
+.idea-card__thumb:focus-visible {
   outline: 3px solid rgba(111, 91, 139, 0.45);
   outline-offset: 3px;
-  border-radius: 16px;
 }
 
 .idea-card__image {
@@ -1372,117 +1256,70 @@ h6,
   object-fit: cover;
 }
 
-.idea-card__palette {
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  padding: 0.65rem 0.85rem;
-  border-radius: 15px;
-  background: rgba(253, 250, 246, 0.78);
-  border: 1px solid rgba(111, 91, 139, 0.16);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+.idea-card__body {
+  display: grid;
+  gap: 0.65rem;
 }
 
-.idea-card__palette-title {
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.idea-card__title {
+  margin: 0;
+  font-size: 1.15rem;
+  line-height: 1.25;
   font-weight: 700;
-  color: var(--text-muted);
+  color: var(--text-primary);
 }
 
-.idea-card__palette-swatches {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.55rem;
-}
-
-.idea-card__swatch {
+.idea-card__link {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.35rem 0.65rem;
-  border-radius: 999px;
-  background: rgba(253, 250, 246, 0.92);
-  border: 1px solid rgba(111, 91, 139, 0.18);
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  color: var(--text-primary);
-  text-transform: uppercase;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--brand-dark);
+  text-decoration: none;
 }
 
-.idea-card__swatch::before {
-  content: '';
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--swatch-color);
-  box-shadow: 0 2px 6px rgba(17, 17, 38, 0.22);
-  border: 2px solid rgba(253, 250, 246, 0.85);
+.idea-card__link::after {
+  content: '↗';
+  font-size: 0.8rem;
+}
+
+.idea-card__link:hover {
+  text-decoration: underline;
 }
 
 .idea-card__note {
   margin: 0;
   color: var(--text-primary);
-  background: rgba(253, 250, 246, 0.82);
+  background: rgba(253, 250, 246, 0.88);
   border-radius: 16px;
-  padding: 0.75rem 0.9rem;
+  padding: 0.85rem 1rem;
   border: 1px solid rgba(111, 91, 139, 0.12);
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
-.idea-card__relations {
-  display: grid;
-  gap: 0.65rem;
+@media (max-width: 1080px) {
+  .ideas-grid {
+    column-width: 240px;
+  }
 }
 
-.idea-card__relation-group {
-  display: grid;
-  gap: 0.4rem;
-  padding: 0.6rem 0.85rem;
-  border-radius: 16px;
-  background: rgba(111, 91, 139, 0.08);
-  border: 1px solid rgba(111, 91, 139, 0.18);
+@media (max-width: 820px) {
+  .ideas-grid {
+    column-width: 210px;
+    column-gap: 1.3rem;
+  }
 }
 
-.idea-card__relation-group--vendors {
-  background: rgba(200, 160, 96, 0.14);
-  border-color: rgba(200, 160, 96, 0.28);
-}
+@media (max-width: 600px) {
+  .ideas-grid {
+    column-width: 100%;
+    column-gap: 1.1rem;
+  }
 
-.idea-card__relation-title {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 700;
-  color: var(--text-muted);
-}
-
-.idea-card__relation-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.idea-card__relation-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  background: rgba(253, 250, 246, 0.92);
-  border: 1px solid rgba(111, 91, 139, 0.18);
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.idea-card__relation-chip:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 14px rgba(45, 35, 56, 0.14);
+  .idea-card {
+    margin-bottom: 1.3rem;
+  }
 }
 
 .idea-card__footer {


### PR DESCRIPTION
## Summary
- streamline the Ideas form to capture title, uploaded imagery, optional reference link, and personal notes while removing unused palette/checklist/provider fields
- adjust the ideas data pipeline to drop the old metadata, support title/note searching, and render Pinterest-style inspiration cards with multi-image thumbnails
- restyle the ideas grid into a masonry layout with refreshed card visuals for consistency across screen sizes

## Testing
- python3 -m http.server 8000 (manual preview)


------
https://chatgpt.com/codex/tasks/task_e_68dd460e0b38832dac78e3ea0271895f