### PR TITLE
Reduce mobile budget target input size

### DIFF
--- a/style.css
+++ b/style.css
@@ -743,6 +743,15 @@ h6,
     align-items: stretch;
   }
 
+  .budget-target {
+    padding: 0.85rem;
+  }
+
+  .budget-target__controls input {
+    padding: 0.55rem 0.85rem;
+    border-radius: 12px;
+  }
+
   .venues-grid,
   .budget-grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- reduce padding for the budget target card and input when the layout switches to the mobile column variant
- keep the budget target form visually compact on phones without affecting larger breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd52e00c84832db9167668cf7cba40