### PR TITLE
Adjust budget target form for mobile layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -2228,6 +2228,22 @@ body.idea-image-viewer-open {
   flex: 1 1 160px;
 }
 
+@media (max-width: 768px) {
+  .budget-target__controls {
+    align-items: center;
+  }
+
+  .budget-target__controls #budget-target {
+    flex: 0 1 60%;
+    max-width: 60%;
+    min-width: 0;
+  }
+
+  .budget-target__controls .button {
+    flex: 1 1 40%;
+  }
+}
+
 .table-wrapper {
   overflow-x: auto;
   border-radius: 18px;


### PR DESCRIPTION
## Summary
- limit the budget target input width on small screens to improve readability
- adjust flex behavior so the "Guardar objetivo" button stays aligned without affecting desktop layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd55233e0c832d83620ad5365d131e