### PR TITLE
Add inline priority editing to checklist tasks

### DIFF
--- a/style.css
+++ b/style.css
@@ -510,6 +510,24 @@ h6,
   text-transform: uppercase;
 }
 
+.task__priority-button {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task__priority-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+}
+
+.task__priority-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .priority--alta {
   background: var(--priority-high-bg);
   color: var(--priority-high-text);


### PR DESCRIPTION
## Summary
- allow cycling a task's priority directly from the checklist using the colored pill button
- add logic to cycle through available priorities and keep local storage/state in sync
- style the priority control for hover/focus feedback to highlight its interactivity

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68df8dd66128832d997c2f8bd0dc8283